### PR TITLE
Fix unicode characters in path on Python 3

### DIFF
--- a/cherrypy/_cptree.py
+++ b/cherrypy/_cptree.py
@@ -286,14 +286,6 @@ class Tree(object):
                 environ['SCRIPT_NAME'] = sn
                 environ['PATH_INFO'] = path[len(sn.rstrip("/")):]
         else:
-            if environ.get(ntou('wsgi.version')) == (ntou('u'), 0):
-                # Python 3/WSGI u.0: all strings MUST be full unicode
-                environ['SCRIPT_NAME'] = sn
-                environ['PATH_INFO'] = path[len(sn.rstrip("/")):]
-            else:
-                # Python 3/WSGI 1.x: all strings MUST be ISO-8859-1 str
-                environ['SCRIPT_NAME'] = sn.encode(
-                    'utf-8').decode('ISO-8859-1')
-                environ['PATH_INFO'] = path[
-                    len(sn.rstrip("/")):].encode('utf-8').decode('ISO-8859-1')
+            environ['SCRIPT_NAME'] = sn
+            environ['PATH_INFO'] = path[len(sn.rstrip("/")):]
         return app(environ, start_response)

--- a/cherrypy/_cptree.py
+++ b/cherrypy/_cptree.py
@@ -261,7 +261,7 @@ class Tree(object):
         # to '' (some WSGI servers always set SCRIPT_NAME to '').
         # Try to look up the app using the full path.
         env1x = environ
-        if environ.get(ntou('wsgi.version')) == (ntou('u'), 0):
+        if not py3k and environ.get(ntou('wsgi.version')) == (ntou('u'), 0):
             env1x = _cpwsgi.downgrade_wsgi_ux_to_1x(environ)
         path = httputil.urljoin(env1x.get('SCRIPT_NAME', ''),
                                 env1x.get('PATH_INFO', ''))

--- a/cherrypy/_cptree.py
+++ b/cherrypy/_cptree.py
@@ -274,17 +274,11 @@ class Tree(object):
 
         # Correct the SCRIPT_NAME and PATH_INFO environ entries.
         environ = environ.copy()
-        if not py3k:
-            if environ.get(ntou('wsgi.version')) == (ntou('u'), 0):
-                # Python 2/WSGI u.0: all strings MUST be of type unicode
-                enc = environ[ntou('wsgi.url_encoding')]
-                environ[ntou('SCRIPT_NAME')] = sn.decode(enc)
-                environ[ntou('PATH_INFO')] = path[
-                    len(sn.rstrip("/")):].decode(enc)
-            else:
-                # Python 2/WSGI 1.x: all strings MUST be of type str
-                environ['SCRIPT_NAME'] = sn
-                environ['PATH_INFO'] = path[len(sn.rstrip("/")):]
+        if not py3k and environ.get(ntou('wsgi.version')) == (ntou('u'), 0):
+            # Python 2/WSGI u.0: all strings MUST be of type unicode
+            enc = environ[ntou('wsgi.url_encoding')]
+            environ[ntou('SCRIPT_NAME')] = sn.decode(enc)
+            environ[ntou('PATH_INFO')] = path[len(sn.rstrip("/")):].decode(enc)
         else:
             environ['SCRIPT_NAME'] = sn
             environ['PATH_INFO'] = path[len(sn.rstrip("/")):]


### PR DESCRIPTION
Variables PATH_INFO and SCRIPT_NAME are already ISO-8859-1 string. Old code makes these variables double encoded. Issue #1194
