### PR TITLE
Fix unicode url in HTTPRedirect on Python 3

### DIFF
--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -253,7 +253,7 @@ class HTTPRedirect(CherryPyException):
             response.headers['Content-Type'] = "text/html;charset=utf-8"
             # "The ... URI SHOULD be given by the Location field
             # in the response."
-            response.headers['Location'] = self.urls[0]
+            response.headers['Location'] = ntob(self.urls[0], 'utf-8')
 
             # "Unless the request method was HEAD, the entity of the response
             # SHOULD contain a short hypertext note with a hyperlink to the
@@ -293,7 +293,7 @@ class HTTPRedirect(CherryPyException):
         elif status == 305:
             # Use Proxy.
             # self.urls[0] should be the URI of the proxy.
-            response.headers['Location'] = self.urls[0]
+            response.headers['Location'] = ntob(self.urls[0], 'utf-8')
             response.body = None
             # Previous code may have set C-L, so we have to reset it.
             response.headers.pop('Content-Length', None)

--- a/cherrypy/test/test_core.py
+++ b/cherrypy/test/test_core.py
@@ -148,7 +148,8 @@ class CoreRequestHandlingTest(helper.CPWebCase):
                 raise cherrypy.HTTPRedirect("/some\"url/that'we/want")
 
             def url_with_unicode(self):
-                raise cherrypy.HTTPRedirect(ntou("\u0442\u0435\u0441\u0442"))
+                raise cherrypy.HTTPRedirect(ntou("\u0442\u0435\u0441\u0442",
+                                                 'escape'))
 
         def login_redir():
             if not getattr(cherrypy.request, "login", None):

--- a/cherrypy/test/test_core.py
+++ b/cherrypy/test/test_core.py
@@ -6,7 +6,7 @@ import sys
 import types
 
 import cherrypy
-from cherrypy._cpcompat import IncompleteRead, itervalues, ntob
+from cherrypy._cpcompat import IncompleteRead, itervalues, ntob, ntou
 from cherrypy import _cptools, tools
 from cherrypy.lib import httputil, static
 from cherrypy.test._test_decorators import ExposeExamples
@@ -146,6 +146,9 @@ class CoreRequestHandlingTest(helper.CPWebCase):
 
             def url_with_quote(self):
                 raise cherrypy.HTTPRedirect("/some\"url/that'we/want")
+
+            def url_with_unicode(self):
+                raise cherrypy.HTTPRedirect(ntou("\u0442\u0435\u0441\u0442"))
 
         def login_redir():
             if not getattr(cherrypy.request, "login", None):
@@ -430,6 +433,12 @@ class CoreRequestHandlingTest(helper.CPWebCase):
         self.getPage("/redirect/url_with_quote")
         self.assertStatus(303)
         assertValidXHTML()
+
+        # check redirect to url containing unicode characters.
+        self.getPage("/redirect/url_with_unicode")
+        self.assertStatus(303)
+        loc = self.assertHeader('Location')
+        assert loc.endswith("\xd1\x82\xd0\xb5\xd1\x81\xd1\x82")
 
     def test_InternalRedirect(self):
         # InternalRedirect


### PR DESCRIPTION
If Location header is unicode string, it will be encoded with rules of RFC 2047 later. Browsers do not understand Location header like =?utf-8?b?....
