### PR TITLE
Fix signal handler registration.

### DIFF
--- a/cherrypy/_cpconfig.py
+++ b/cherrypy/_cpconfig.py
@@ -282,9 +282,11 @@ def _engine_namespace_handler(k, v):
     elif k == 'deadlock_poll_freq':
         engine.timeout_monitor.frequency = v
     elif k == 'SIGHUP':
-        engine.listeners['SIGHUP'] = set([v])
+        if v is not None:
+            engine.subscribe('SIGHUP', v)
     elif k == 'SIGTERM':
-        engine.listeners['SIGTERM'] = set([v])
+        if v is not None:
+            engine.subscribe('SIGTERM', v)
     elif "." in k:
         plugin, attrname = k.split(".", 1)
         plugin = getattr(engine, plugin)


### PR DESCRIPTION
Using configuration options like these:

```
'engine.SIGHUP': None
'engine.SIGTERM': None
```

causes exceptions to be thrown when handling SIGTERM or SIGHUP signals
because listeners are registered without entries in the `_priorities`
dictionary.

In `_cpconfig.py`, the following code registers a SIGTERM handler:

```
engine.listeners['SIGTERM'] = set([v])
```

In `process/wspbus.py`, the publish method gets called when signal is
received and executes the following code:

```
items = [(self._priorities[(channel, listener)], listener)
     for listener in self.listeners[channel]]
```

`self._priorities` dictionary does not have the necessary key and KeyError
is thrown.
