### PR TITLE
Patch for #1352

### DIFF
--- a/cherrypy/test/test_encoding.py
+++ b/cherrypy/test/test_encoding.py
@@ -246,6 +246,14 @@ class EncodingTests(helper.CPWebCase):
                      body=body),
         self.assertBody(ntob("submit: Create, text: ab\xe2\x80\x9cc"))
 
+    def test_multipart_decoding_bigger_maxrambytes(self):
+        # Test the decoding of a multipart entity when the entity is bigger
+        # than maxrambytes. See ticket #1352.
+        maxrambytes_original = cherrypy._cpreqbody.Part.maxrambytes
+        cherrypy._cpreqbody.Part.maxrambytes = 1
+        self.test_multipart_decoding()
+        cherrypy._cpreqbody.Part.maxrambytes = maxrambytes_original
+
     def test_multipart_decoding_no_charset(self):
         # Test the decoding of a multipart entity when the charset (utf8) is
         # NOT explicitly given, but is in the list of charsets to attempt.


### PR DESCRIPTION
Fix for #1352
I moved the part responsible for encoding a field value. This way the value gets encoded no matter if it was cached in a file or not.
A test case is included. Is setting `cherrypy._cpreqbody.Part.maxrambytes` inside a test case ok?
