### PR TITLE
Systemd socket activation

### DIFF
--- a/cherrypy/process/servers.py
+++ b/cherrypy/process/servers.py
@@ -113,6 +113,7 @@ Please see `Lighttpd FastCGI Docs
 an explanation of the possible configuration options.
 """
 
+import os
 import sys
 import time
 import warnings
@@ -227,9 +228,12 @@ class ServerAdapter(object):
             time.sleep(.1)
 
         # Wait for port to be occupied
-        if isinstance(self.bind_addr, tuple):
-            host, port = self.bind_addr
-            wait_for_occupied_port(host, port)
+        if not os.environ.get('LISTEN_PID', None):
+            # Wait for port to be occupied if not running via socket-activation
+            # (for socket-activation the port will be managed by systemd )
+            if isinstance(self.bind_addr, tuple):
+                host, port = self.bind_addr
+                wait_for_occupied_port(host, port)
 
     def stop(self):
         """Stop the HTTP server."""

--- a/cherrypy/wsgiserver/__init__.py
+++ b/cherrypy/wsgiserver/__init__.py
@@ -1925,7 +1925,10 @@ class HTTPServer(object):
         interface" (INADDR_ANY), and '::' is the similar IN6ADDR_ANY for
         IPv6. The empty string or None are not allowed.
 
-        For UNIX sockets, supply the filename as a string.""")
+        For UNIX sockets, supply the filename as a string.
+
+        Systemd socket activation is automatic and doesn't require tempering
+        with this variable""")
 
     def start(self):
         """Run the server forever."""

--- a/cherrypy/wsgiserver/__init__.py
+++ b/cherrypy/wsgiserver/__init__.py
@@ -1939,7 +1939,11 @@ class HTTPServer(object):
             self.software = "%s Server" % self.version
 
         # Select the appropriate socket
-        if isinstance(self.bind_addr, six.string_types):
+        self.socket = None
+        if os.getenv('LISTEN_PID', None):
+            # systemd socket activation
+            self.socket = socket.fromfd(3, socket.AF_INET, socket.SOCK_STREAM)
+        elif isinstance(self.bind_addr, six.string_types):
             # AF_UNIX socket
 
             # So we can reuse the socket...
@@ -1973,21 +1977,21 @@ class HTTPServer(object):
                     info = [(socket.AF_INET, socket.SOCK_STREAM,
                              0, "", self.bind_addr)]
 
-        self.socket = None
-        msg = "No socket could be created"
-        for res in info:
-            af, socktype, proto, canonname, sa = res
-            try:
-                self.bind(af, socktype, proto)
-            except socket.error as serr:
-                msg = "%s -- (%s: %s)" % (msg, sa, serr)
-                if self.socket:
-                    self.socket.close()
-                self.socket = None
-                continue
-            break
         if not self.socket:
-            raise socket.error(msg)
+            msg = "No socket could be created"
+            for res in info:
+                af, socktype, proto, canonname, sa = res
+                try:
+                    self.bind(af, socktype, proto)
+                    break
+                except socket.error as serr:
+                    msg = "%s -- (%s: %s)" % (msg, sa, serr)
+                    if self.socket:
+                        self.socket.close()
+                    self.socket = None
+
+            if not self.socket:
+                raise socket.error(msg)
 
         # Timeout so KeyboardInterrupt can be caught on Win32
         self.socket.settimeout(1)

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -84,6 +84,19 @@ provide a 'pidfile' argument, preferably an absolute path:
 
    PIDFile(cherrypy.engine, '/var/run/myapp.pid').subscribe()
 
+Systemd socket activation
+#######################
+
+Socket Activation is a systemd feature that allows to setup a system so that
+the systemd will sit on a port and start services 'on demand' (a little bit
+like inetd and xinetd used to do).
+
+CherryPy has built-in socket activation support, if run from a systemd
+service file it will detect the `LISTEN_PID` environment variable to know that
+it should consider fd 3 to be the passed socket.
+
+To read more about socket activation:
+http://0pointer.de/blog/projects/socket-activation.html
 
 Control via Supervisord
 #######################


### PR DESCRIPTION
This tiny patch implements systemd's socket activation mechanism[0] for
cherrypy servers, it's based on work sponsored by Endless Computers[1] to
package kalite[2] as a flatpak[3].

Socket Activation allows to setup a system so that systemd will sit on a
port and start services 'on demand' (a little bit like inetd and xinetd
used to do). This patch makes that mechanism work for any cherrypy
service without modification.

[0] http://0pointer.de/blog/projects/socket-activation.html
[1] https://endlessm.com
[2] https://learningequality.org/ka-lite/
[3] https://flatpak.org

https://phabricator.endlessm.com/T4489

Signed-off-by: Niv Sardi xaiki@evilgiggle.com
