### PR TITLE
Add testing against loosely supported Python versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ python:
 - nightly
 matrix:
   allow_failures:
-    - 3.1
-    - pypy
-    - pypy3
-    - nightly
+    python:
+      - 3.1
+      - pypy
+      - pypy3
+      - nightly
 env:
 - WEBTEST_INTERACTIVE=false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
 - nightly
 matrix:
   allow_failures:
-    python:
+    - python:
       - 3.1
       - pypy
       - pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,20 @@ language: python
 python:
 - 2.6
 - 2.7
+- 3.1
 - 3.2
 - 3.3
 - 3.4
 - 3.5
+- pypy
+- pypy3
+- nightly
+matrix:
+  allow_failures:
+    - 3.1
+    - pypy
+    - pypy3
+    - nightly
 env:
 - WEBTEST_INTERACTIVE=false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,10 @@ python:
 - nightly
 matrix:
   allow_failures:
-    - python:
-      - 3.1
-      - pypy
-      - pypy3
-      - nightly
+    - python: 3.1
+    - python: pypy
+    - python: pypy3
+    - python: nightly
 env:
 - WEBTEST_INTERACTIVE=false
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,13 @@ matrix:
     - python: pypy
     - python: pypy3
     - python: nightly
+
 env:
 - WEBTEST_INTERACTIVE=false
-script:
-- pip install -e .
-- nosetests
+
+install: pip install -e .
+script: nosetests
+
 deploy:
   provider: pypi
   on:


### PR DESCRIPTION
@jaraco I've mentioned classifiers declaring support of Python 3.1in `setup.py`, which isn't tested at all.
Also, there are several extra unsupported or unstable environments, which are useful for testing against.

As an experiment, I've added testing against `3.1`, `nightly`, `pypy` and `pypy3` targets. I've marked them as allowed to fail, so it won't affect overall build status. Let's try it out if you don't mind. This will help cherrypy detect possible issues with future versions of Python.

Plz let me know your opinion on this.
