### PR TITLE
Added Content-Length handling in webtest

### DIFF
--- a/cherrypy/test/test_json.py
+++ b/cherrypy/test/test_json.py
@@ -78,6 +78,11 @@ class JsonTest(helper.CPWebCase):
         self.assertBody('ok')
 
         body = '[13, "c"]'
+        headers = [('Content-Type', 'application/json')]
+        self.getPage("/json_post", method="POST", headers=headers, body=body)
+        self.assertBody('ok')
+
+        body = '[13, "c"]'
         headers = [('Content-Type', 'text/plain'),
                    ('Content-Length', str(len(body)))]
         self.getPage("/json_post", method="POST", headers=headers, body=body)

--- a/cherrypy/test/test_request_obj.py
+++ b/cherrypy/test/test_request_obj.py
@@ -761,7 +761,7 @@ class RequestObjectTests(helper.CPWebCase):
         # Provide a C-T or webtest will provide one (and a C-L) for us.
         h = [("Content-Type", "text/plain")]
         self.getPage("/method/reachable", headers=h, method="PUT")
-        self.assertStatus(411)
+        self.assertStatus(200)
 
         # Request a custom method with a request body
         b = ('<?xml version="1.0" encoding="utf-8" ?>\n\n'

--- a/cherrypy/test/webtest.py
+++ b/cherrypy/test/webtest.py
@@ -485,14 +485,17 @@ def cleanHeaders(headers, method, body, host, port):
 
     if method in methods_with_bodies:
         # Stick in default type and length headers if not present
-        found = False
+        found_content_type = False
+        found_content_length = False
         for k, v in headers:
             if k.lower() == 'content-type':
-                found = True
-                break
-        if not found:
+                found_content_type = True
+            if k.lower() == 'content-length':
+                found_content_length = True
+        if not found_content_type:
             headers.append(
                 ("Content-Type", "application/x-www-form-urlencoded"))
+        if not found_content_length:
             headers.append(("Content-Length", str(len(body or ""))))
 
     return headers


### PR DESCRIPTION
The webtest client does not add the Content-Length header, unless you don't provide Content-Type in which case it adds `Content-Type: application/x-www-form-urlencoded` and the Content-Length. This makes cumbersome to test JSON requests, since then you need another Content-Type and have to add Content-Length manually.

This PR changes the logic in order to add Content-Length if missing.

However, this prevents testing requests with no headers (i.e. the changed test in test_request_obj). I'm not sure if this patch is acceptable but since I had already written it after I realized this issue, here it is.
