### PR TITLE
Fix systemd socket activation (#1492)

### DIFF
--- a/cherrypy/process/servers.py
+++ b/cherrypy/process/servers.py
@@ -166,9 +166,10 @@ class ServerAdapter(object):
         if not self.httpserver:
             raise ValueError("No HTTP server has been created.")
 
-        # Start the httpserver in a new thread.
-        if isinstance(self.bind_addr, tuple):
-            wait_for_free_port(*self.bind_addr)
+        if not os.environ.get('LISTEN_PID', None):
+            # Start the httpserver in a new thread.
+            if isinstance(self.bind_addr, tuple):
+                wait_for_free_port(*self.bind_addr)
 
         import threading
         t = threading.Thread(target=self._start_http_thread)


### PR DESCRIPTION
when starting up cherrypy via socket activation we
should not wait for the port to become free because
systemd is bound to it.
