### PR TITLE
Fixes for builtin SSL provider

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+8.1.1
+-----
+
+* #1497: Handle errors thrown by ``ssl_module: 'builtin'``
+  when client opens connection to HTTPS port using HTTP.
+
 8.1.0
 -----
 

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -79,10 +79,10 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
                 # the 'ping' isn't SSL.
                 return None, {}
             elif e.errno == ssl.SSL_ERROR_SSL:
-                if e.args[1].endswith('http request'):
+                if 'http request' in e.args[1]:
                     # The client is speaking HTTP to an HTTPS server.
                     raise wsgiserver.NoSSLError
-                elif e.args[1].endswith('unknown protocol'):
+                elif 'unknown protocol' in e.args[1]:
                     # The client is speaking some non-HTTP protocol.
                     # Drop the conn.
                     return None, {}

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -86,6 +86,11 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
                     # The client is speaking some non-HTTP protocol.
                     # Drop the conn.
                     return None, {}
+            elif 'handshake operation timed out' in e.args[0]:
+                # This error is thrown by builtin SSL after a timeout
+                # when client is speaking HTTP to an HTTPS server.
+                # The connection can safely be dropped.
+                return None, {}
             raise
         return s, self.get_environ(s)
 


### PR DESCRIPTION
- Fixes error #1497 by not only checking at end of the error.
- Also fixes another error where the builtin provider will throw `The handshake operation timed out` even though a response was already send to the non-HTTPS client. I will admit that am not sure why this happens, but it does.

Tested on Ubuntu and Windows 10, both producing the errors described above.
