### PR TITLE
Deprecated cgi in python3 #1330

### DIFF
--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -341,7 +341,10 @@ except ImportError:
 
 # html module needed the argument quote=False because in cgi the default
 # is False. With quote=True the results differ.
+
 def escape_html(s, escape_quote=False):
-    """Replace special characters "&", "<" and ">" to HTML-safe sequences. When
-    escape_quote=True, escape (') and (") chars."""
+    """Replace special characters "&", "<" and ">" to HTML-safe sequences.
+
+    When escape_quote=True, escape (') and (") chars.
+    """
     return escape(s, quote=escape_quote)

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -341,7 +341,7 @@ except ImportError:
 
 # html module needed the argument quote=False because in cgi the default
 # is False. With quote=True the results differ.
-def escape_html(s, quote=False):
+def escape_html(s, escape_quote=False):
     """Replace special characters "&", "<" and ">" to HTML-safe sequences. When
-    quote=True, escape (') and (") chars."""
-    return escape(s, quote=quote)
+    escape_quote=True, escape (') and (") chars."""
+    return escape(s, quote=escape_quote)

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -333,12 +333,14 @@ except ImportError:
 
         return args
 
-if six.PY2:
-    from cgi import escape as escape_html
-else:
+# html module come in 3.2 version
+try:
     from html import escape
+except:
+    from cgi import escape
 
-    def escape_html(s):
-        """In py3 version is needed the argument quote=False to produce same results"""
-
-        return escape(s, quote=False)
+# html module needed the argument quote=False because in cgi the default
+# is False. With quote=True the results differ.
+def escape_html(s):
+    """Replace special characters "&", "<" and ">" to HTML-safe sequences."""
+    return escape(s, quote=False)

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -334,7 +334,7 @@ except ImportError:
         return args
 
 if six.PY2:
-    from cgi import escape as _escape
+    from cgi import escape as escape_html
 else:
-    from html import escape as _escape
+    from html import escape as escape_html
 

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -336,5 +336,9 @@ except ImportError:
 if six.PY2:
     from cgi import escape as escape_html
 else:
-    from html import escape as escape_html
+    from html import escape
 
+    def escape_html(s):
+        """In py3 version is needed the argument quote=False to produce same results"""
+
+        return escape(s, quote=False)

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -336,11 +336,12 @@ except ImportError:
 # html module come in 3.2 version
 try:
     from html import escape
-except:
+except ImportError:
     from cgi import escape
 
 # html module needed the argument quote=False because in cgi the default
 # is False. With quote=True the results differ.
-def escape_html(s):
-    """Replace special characters "&", "<" and ">" to HTML-safe sequences."""
-    return escape(s, quote=False)
+def escape_html(s, quote=False):
+    """Replace special characters "&", "<" and ">" to HTML-safe sequences. When
+    quote=True, escape (') and (") chars."""
+    return escape(s, quote=quote)

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -332,3 +332,9 @@ except ImportError:
             args.append('-W' + opt)
 
         return args
+
+if six.PY2:
+    from cgi import escape as _escape
+else:
+    from html import escape as _escape
+

--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -116,13 +116,13 @@ and not simply return an error message as a result.
 """
 
 import contextlib
-from cgi import escape as _escape
 from sys import exc_info as _exc_info
 from traceback import format_exception as _format_exception
 from xml.sax import saxutils
 
 import six
 
+from cherrypy._cpcompat import _escape
 from cherrypy._cpcompat import text_or_bytes, iteritems, ntob
 from cherrypy._cpcompat import tonative, urljoin as _urljoin
 from cherrypy.lib import httputil as _httputil

--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -122,7 +122,7 @@ from xml.sax import saxutils
 
 import six
 
-from cherrypy._cpcompat import _escape
+from cherrypy._cpcompat import escape_html
 from cherrypy._cpcompat import text_or_bytes, iteritems, ntob
 from cherrypy._cpcompat import tonative, urljoin as _urljoin
 from cherrypy.lib import httputil as _httputil
@@ -502,7 +502,7 @@ def get_error_page(status, **kwargs):
         if v is None:
             kwargs[k] = ''
         else:
-            kwargs[k] = _escape(kwargs[k])
+            kwargs[k] = escape_html(kwargs[k])
 
     # Use a custom template or callable for the error page?
     pages = cherrypy.serving.request.error_page

--- a/cherrypy/test/test_compat.py
+++ b/cherrypy/test/test_compat.py
@@ -28,7 +28,7 @@ class EscapeTester(unittest.TestCase):
     """
 
     def test_escape_quote(self):
-        """test_escape_quote - Verify the output for &<>" chars
+        """test_escape_quote - Verify the output for &<>"' chars.
         """
-        self.assertEqual('xx&amp;&lt;&gt;"aa', compat.escape_html('xx&<>"aa'))
 
+        self.assertEqual("""xx&amp;&lt;&gt;"aa'""", compat.escape_html("""xx&<>"aa'"""))

--- a/cherrypy/test/test_compat.py
+++ b/cherrypy/test/test_compat.py
@@ -24,11 +24,8 @@ class StringTester(unittest.TestCase):
 
 
 class EscapeTester(unittest.TestCase):
-    """Class to test escape_html function from _cpcompat.
-    """
+    """Class to test escape_html function from _cpcompat."""
 
     def test_escape_quote(self):
-        """test_escape_quote - Verify the output for &<>"' chars.
-        """
-
+        """test_escape_quote - Verify the output for &<>"' chars."""
         self.assertEqual("""xx&amp;&lt;&gt;"aa'""", compat.escape_html("""xx&<>"aa'"""))

--- a/cherrypy/test/test_compat.py
+++ b/cherrypy/test/test_compat.py
@@ -26,17 +26,17 @@ class StringTester(unittest.TestCase):
 class EscapeTester(unittest.TestCase):
 
     def test_escape_module(self):
-        """test_escape_module - Verify the imported module to _escape function
+        """test_escape_module - Verify the imported module to escape_html function
 
         See #1330.
         """
         if six.PY2: # See discussion on https://docs.python.org/3/howto/pyporting.html
-            self.assertEqual('cgi', compat._escape.__module__)
+            self.assertEqual('cgi', compat.escape_html.__module__)
         else:
-            self.assertEqual('html', compat._escape.__module__)
+            self.assertEqual('html', compat.escape_html.__module__)
 
     def test_escape_quote(self):
         """test_escape_quote - Verify the output for &<>" chars
         """
-        self.assertEqual('xx&amp;&lt;&gt;"aa', compat._escape('xx&<>"aa'))
+        self.assertEqual('xx&amp;&lt;&gt;"aa', compat.escape_html('xx&<>"aa'))
 

--- a/cherrypy/test/test_compat.py
+++ b/cherrypy/test/test_compat.py
@@ -30,7 +30,6 @@ class EscapeTester(unittest.TestCase):
 
         See #1330.
         """
-        print("_escape:", compat._escape.__module__)
         if six.PY2: # See discussion on https://docs.python.org/3/howto/pyporting.html
             self.assertEqual('cgi', compat._escape.__module__)
         else:

--- a/cherrypy/test/test_compat.py
+++ b/cherrypy/test/test_compat.py
@@ -24,6 +24,8 @@ class StringTester(unittest.TestCase):
 
 
 class EscapeTester(unittest.TestCase):
+    """Class to test escape_html function from _cpcompat.
+    """
 
     def test_escape_module(self):
         """test_escape_module - Verify the imported module to escape_html function

--- a/cherrypy/test/test_compat.py
+++ b/cherrypy/test/test_compat.py
@@ -21,3 +21,23 @@ class StringTester(unittest.TestCase):
         if six.PY3:
             raise nose.SkipTest('Only useful on Python 2')
         self.assertRaises(Exception, compat.ntob, 'fight')
+
+
+class EscapeTester(unittest.TestCase):
+
+    def test_escape_module(self):
+        """test_escape_module - Verify the imported module to _escape function
+
+        See #1330.
+        """
+        print("_escape:", compat._escape.__module__)
+        if six.PY2: # See discussion on https://docs.python.org/3/howto/pyporting.html
+            self.assertEqual('cgi', compat._escape.__module__)
+        else:
+            self.assertEqual('html', compat._escape.__module__)
+
+    def test_escape_quote(self):
+        """test_escape_quote - Verify the output for &<>" chars
+        """
+        self.assertEqual('xx&amp;&lt;&gt;"aa', compat._escape('xx&<>"aa'))
+

--- a/cherrypy/test/test_compat.py
+++ b/cherrypy/test/test_compat.py
@@ -27,16 +27,6 @@ class EscapeTester(unittest.TestCase):
     """Class to test escape_html function from _cpcompat.
     """
 
-    def test_escape_module(self):
-        """test_escape_module - Verify the imported module to escape_html function
-
-        See #1330.
-        """
-        if six.PY2: # See discussion on https://docs.python.org/3/howto/pyporting.html
-            self.assertEqual('cgi', compat.escape_html.__module__)
-        else:
-            self.assertEqual('html', compat.escape_html.__module__)
-
     def test_escape_quote(self):
         """test_escape_quote - Verify the output for &<>" chars
         """


### PR DESCRIPTION
Use import especific to py2 or py3 to escape function from older cgi or newest html module in python3, conform #1330.
