### PR TITLE
Add attribute "ssl_ciphers" to support configuration cipher suites by cherrypy

### DIFF
--- a/cherrypy/_cpnative_server.py
+++ b/cherrypy/_cpnative_server.py
@@ -144,6 +144,7 @@ class CPHTTPServer(wsgiserver.HTTPServer):
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
+                self.server_adapter.ssl_ciphers,
                 self.server_adapter.ssl_certificate_chain)
             self.ssl_adapter.context = self.server_adapter.ssl_context
         elif self.server_adapter.ssl_certificate:
@@ -151,4 +152,5 @@ class CPHTTPServer(wsgiserver.HTTPServer):
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
+                self.server_adapter.ssl_ciphers,
                 self.server_adapter.ssl_certificate_chain)

--- a/cherrypy/_cpnative_server.py
+++ b/cherrypy/_cpnative_server.py
@@ -144,13 +144,13 @@ class CPHTTPServer(wsgiserver.HTTPServer):
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_ciphers,
-                self.server_adapter.ssl_certificate_chain)
+                self.server_adapter.ssl_certificate_chain,
+                self.server_adapter.ssl_ciphers)
             self.ssl_adapter.context = self.server_adapter.ssl_context
         elif self.server_adapter.ssl_certificate:
             adapter_class = wsgiserver.get_ssl_adapter_class(ssl_module)
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_ciphers,
-                self.server_adapter.ssl_certificate_chain)
+                self.server_adapter.ssl_certificate_chain,
+                self.server_adapter.ssl_ciphers)

--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -113,6 +113,9 @@ class Server(ServerAdapter):
     ssl_private_key = None
     """The filename of the private key to use with SSL."""
 
+     ssl_ciphers = None
+    """The ciphers list of SSL"""
+    
     if six.PY3:
         ssl_module = 'builtin'
         """The name of a registered SSL adaptation module to use with

--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -113,7 +113,7 @@ class Server(ServerAdapter):
     ssl_private_key = None
     """The filename of the private key to use with SSL."""
 
-     ssl_ciphers = None
+    ssl_ciphers = None
     """The ciphers list of SSL"""
     
     if six.PY3:

--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -115,6 +115,7 @@ class Server(ServerAdapter):
 
     ssl_ciphers = None
     """The ciphers list of SSL"""
+    
     if six.PY3:
         ssl_module = 'builtin'
         """The name of a registered SSL adaptation module to use with

--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -115,7 +115,7 @@ class Server(ServerAdapter):
 
     ssl_ciphers = None
     """The ciphers list of SSL"""
-    
+
     if six.PY3:
         ssl_module = 'builtin'
         """The name of a registered SSL adaptation module to use with

--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -115,7 +115,6 @@ class Server(ServerAdapter):
 
     ssl_ciphers = None
     """The ciphers list of SSL"""
-    
     if six.PY3:
         ssl_module = 'builtin'
         """The name of a registered SSL adaptation module to use with

--- a/cherrypy/_cpwsgi_server.py
+++ b/cherrypy/_cpwsgi_server.py
@@ -54,16 +54,16 @@ class CPWSGIServer(wsgiserver.CherryPyWSGIServer):
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_ciphers,
-                self.server_adapter.ssl_certificate_chain)
+                self.server_adapter.ssl_certificate_chain,
+                self.server_adapter.ssl_ciphers)
             self.ssl_adapter.context = self.server_adapter.ssl_context
         elif self.server_adapter.ssl_certificate:
             adapter_class = wsgiserver.get_ssl_adapter_class(ssl_module)
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_ciphers,
-                self.server_adapter.ssl_certificate_chain)
+                self.server_adapter.ssl_certificate_chain,
+                self.server_adapter.ssl_ciphers)
 
         self.stats['Enabled'] = getattr(
             self.server_adapter, 'statistics', False)

--- a/cherrypy/_cpwsgi_server.py
+++ b/cherrypy/_cpwsgi_server.py
@@ -54,6 +54,7 @@ class CPWSGIServer(wsgiserver.CherryPyWSGIServer):
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
+                self.server_adapter.ssl_ciphers,
                 self.server_adapter.ssl_certificate_chain)
             self.ssl_adapter.context = self.server_adapter.ssl_context
         elif self.server_adapter.ssl_certificate:
@@ -61,6 +62,7 @@ class CPWSGIServer(wsgiserver.CherryPyWSGIServer):
             self.ssl_adapter = adapter_class(
                 self.server_adapter.ssl_certificate,
                 self.server_adapter.ssl_private_key,
+                self.server_adapter.ssl_ciphers,
                 self.server_adapter.ssl_certificate_chain)
 
         self.stats['Enabled'] = getattr(

--- a/cherrypy/wsgiserver/__init__.py
+++ b/cherrypy/wsgiserver/__init__.py
@@ -1771,7 +1771,7 @@ class SSLAdapter(object):
           socket file object``
     """
 
-    def __init__(self, certificate, private_key, ciphers, certificate_chain=None):
+    def __init__(self, certificate, private_key, certificate_chain=None, ciphers):
         self.certificate = certificate
         self.private_key = private_key
         self.ciphers = ciphers

--- a/cherrypy/wsgiserver/__init__.py
+++ b/cherrypy/wsgiserver/__init__.py
@@ -1771,7 +1771,7 @@ class SSLAdapter(object):
           socket file object``
     """
 
-    def __init__(self, certificate, private_key, certificate_chain=None, ciphers):
+    def __init__(self, certificate, private_key, certificate_chain=None, ciphers=None):
         self.certificate = certificate
         self.private_key = private_key
         self.ciphers = ciphers

--- a/cherrypy/wsgiserver/__init__.py
+++ b/cherrypy/wsgiserver/__init__.py
@@ -1771,9 +1771,10 @@ class SSLAdapter(object):
           socket file object``
     """
 
-    def __init__(self, certificate, private_key, certificate_chain=None):
+    def __init__(self, certificate, private_key, ciphers, certificate_chain=None):
         self.certificate = certificate
         self.private_key = private_key
+        self.ciphers = ciphers
         self.certificate_chain = certificate_chain
 
     def wrap(self, sock):

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -36,17 +36,21 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
 
     certificate_chain = None
     """The filename of the certificate chain file."""
+    
+    ciphers = None
+    """The ciphers list of SSL"""
 
     """The ssl.SSLContext that will be used to wrap sockets where available
     (on Python > 2.7.9 / 3.3)
     """
     context = None
 
-    def __init__(self, certificate, private_key, certificate_chain=None):
+    def __init__(self, certificate, private_key, ciphers, certificate_chain=None):
         if ssl is None:
             raise ImportError('You must install the ssl module to use HTTPS.')
         self.certificate = certificate
         self.private_key = private_key
+        self.ciphers = ciphers
         self.certificate_chain = certificate_chain
         if hasattr(ssl, 'create_default_context'):
             self.context = ssl.create_default_context(
@@ -54,6 +58,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
                 cafile=certificate_chain
             )
             self.context.load_cert_chain(certificate, private_key)
+            self.context.set_ciphers(ciphers)
 
     def bind(self, sock):
         """Wrap and return the given socket."""

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -36,7 +36,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
 
     certificate_chain = None
     """The filename of the certificate chain file."""
-    
+
     ciphers = None
     """The ciphers list of SSL"""
 

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -39,6 +39,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
 
     ciphers = None
     """The ciphers list of SSL"""
+    
     """The ssl.SSLContext that will be used to wrap sockets where available
     (on Python > 2.7.9 / 3.3)
     """
@@ -57,7 +58,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
                 cafile=certificate_chain
             )
             self.context.load_cert_chain(certificate, private_key)
-            if (self.ciphers != None):
+            if self.ciphers != None :
                 self.context.set_ciphers(ciphers)
 
     def bind(self, sock):

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -39,7 +39,6 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
 
     ciphers = None
     """The ciphers list of SSL"""
-
     """The ssl.SSLContext that will be used to wrap sockets where available
     (on Python > 2.7.9 / 3.3)
     """

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -44,7 +44,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
     """
     context = None
 
-    def __init__(self, certificate, private_key, ciphers, certificate_chain=None):
+    def __init__(self, certificate, private_key, certificate_chain=None, ciphers):
         if ssl is None:
             raise ImportError('You must install the ssl module to use HTTPS.')
         self.certificate = certificate

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -44,7 +44,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
     """
     context = None
 
-    def __init__(self, certificate, private_key, certificate_chain=None, ciphers):
+    def __init__(self, certificate, private_key, certificate_chain=None, ciphers=None):
         if ssl is None:
             raise ImportError('You must install the ssl module to use HTTPS.')
         self.certificate = certificate

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -57,7 +57,8 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
                 cafile=certificate_chain
             )
             self.context.load_cert_chain(certificate, private_key)
-            self.context.set_ciphers(ciphers)
+            if(self.ciphers != None):
+                self.context.set_ciphers(ciphers)
 
     def bind(self, sock):
         """Wrap and return the given socket."""

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -58,7 +58,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
                 cafile=certificate_chain
             )
             self.context.load_cert_chain(certificate, private_key)
-            if self.ciphers != None :
+            if (self.ciphers is not None):
                 self.context.set_ciphers(ciphers)
 
     def bind(self, sock):

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -39,7 +39,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
 
     ciphers = None
     """The ciphers list of SSL"""
-    
+
     """The ssl.SSLContext that will be used to wrap sockets where available
     (on Python > 2.7.9 / 3.3)
     """

--- a/cherrypy/wsgiserver/ssl_builtin.py
+++ b/cherrypy/wsgiserver/ssl_builtin.py
@@ -57,7 +57,7 @@ class BuiltinSSLAdapter(wsgiserver.SSLAdapter):
                 cafile=certificate_chain
             )
             self.context.load_cert_chain(certificate, private_key)
-            if(self.ciphers != None):
+            if (self.ciphers != None):
                 self.context.set_ciphers(ciphers)
 
     def bind(self, sock):

--- a/cherrypy/wsgiserver/ssl_pyopenssl.py
+++ b/cherrypy/wsgiserver/ssl_pyopenssl.py
@@ -158,8 +158,6 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
     private_key = None
     """The filename of the server's private key file."""
     
-    ciphers = None
-    """The ciphers of SSL."""
 
     certificate_chain = None
     """Optional. The filename of CA's intermediate certificate bundle.
@@ -167,7 +165,7 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
     This is needed for cheaper "chained root" SSL certificates, and should be
     left as None if not required."""
 
-    def __init__(self, certificate, private_key, ciphers, certificate_chain=None):
+    def __init__(self, certificate, private_key, certificate_chain=None):
         if SSL is None:
             raise ImportError('You must install pyOpenSSL to use HTTPS.')
 
@@ -175,7 +173,6 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
         self.certificate = certificate
         self.private_key = private_key
         self.certificate_chain = certificate_chain
-        self.ciphers = ciphers
         self._environ = None
 
     def bind(self, sock):

--- a/cherrypy/wsgiserver/ssl_pyopenssl.py
+++ b/cherrypy/wsgiserver/ssl_pyopenssl.py
@@ -157,7 +157,7 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
 
     private_key = None
     """The filename of the server's private key file."""
-   
+
     certificate_chain = None
     """Optional. The filename of CA's intermediate certificate bundle.
 

--- a/cherrypy/wsgiserver/ssl_pyopenssl.py
+++ b/cherrypy/wsgiserver/ssl_pyopenssl.py
@@ -157,6 +157,9 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
 
     private_key = None
     """The filename of the server's private key file."""
+    
+    ciphers = None
+    """The ciphers of SSL."""
 
     certificate_chain = None
     """Optional. The filename of CA's intermediate certificate bundle.
@@ -164,7 +167,7 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
     This is needed for cheaper "chained root" SSL certificates, and should be
     left as None if not required."""
 
-    def __init__(self, certificate, private_key, certificate_chain=None):
+    def __init__(self, certificate, private_key, ciphers, certificate_chain=None):
         if SSL is None:
             raise ImportError('You must install pyOpenSSL to use HTTPS.')
 
@@ -172,6 +175,7 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
         self.certificate = certificate
         self.private_key = private_key
         self.certificate_chain = certificate_chain
+        self.ciphers = ciphers
         self._environ = None
 
     def bind(self, sock):

--- a/cherrypy/wsgiserver/ssl_pyopenssl.py
+++ b/cherrypy/wsgiserver/ssl_pyopenssl.py
@@ -157,7 +157,7 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
 
     private_key = None
     """The filename of the server's private key file."""
-    
+   
     certificate_chain = None
     """Optional. The filename of CA's intermediate certificate bundle.
 

--- a/cherrypy/wsgiserver/ssl_pyopenssl.py
+++ b/cherrypy/wsgiserver/ssl_pyopenssl.py
@@ -158,7 +158,6 @@ class pyOpenSSLAdapter(wsgiserver.SSLAdapter):
     private_key = None
     """The filename of the server's private key file."""
     
-
     certificate_chain = None
     """Optional. The filename of CA's intermediate certificate bundle.
 


### PR DESCRIPTION
Hi Team,
    Our security team got a request recently, need to dynamiclly set cipher suites of https connections.

     Since Python(version >= 2.7.9)support "context.set_ciphers()", then we can add attribute "ssl_ciphers", and transfer it to "ssl_builtin.py". Thus, if cherrypy use builtin ssl lib, it can dynamicly configure the cipher suites.
   
   I have a solution to add the attribute, could you please merge it once you pass the review?

Thanks,
Cindy

UPD: cc #1523