### PR TITLE
Fix for issue 1530

### DIFF
--- a/cherrypy/_cpdispatch.py
+++ b/cherrypy/_cpdispatch.py
@@ -102,7 +102,13 @@ def test_callable_spec(callable, callable_args, callable_kwargs):
             # the original error
             raise
 
-    if args and args[0] == 'self':
+    if args and (
+            # For callable objects, which have a __call__(self) method
+            hasattr(callable, '__call__') or
+            # For normal methods
+            inspect.ismethod(callable)
+    ):
+        # Strip 'self'
         args = args[1:]
 
     arg_usage = dict([(arg, 0,) for arg in args])

--- a/cherrypy/test/test_request_obj.py
+++ b/cherrypy/test/test_request_obj.py
@@ -252,7 +252,7 @@ class RequestObjectTests(helper.CPWebCase):
             def reachable(self):
                 return 'success'
 
-        class Divorce:
+        class Divorce(Test):
 
             """HTTP Method handlers shouldn't collide with normal method names.
             For example, a GET-handler shouldn't collide with a method named
@@ -280,8 +280,6 @@ class RequestObjectTests(helper.CPWebCase):
             def get(self, ID):
                 return ('Divorce document %s: %s' %
                         (ID, self.documents.get(ID, 'empty')))
-
-        root.divorce = Divorce()
 
         class ThreadLocal(Test):
 

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ data_files = [
     ('cherrypy', [
         'cherrypy/cherryd',
         'cherrypy/favicon.ico',
-        'cherrypy/LICENSE.txt',
+        'LICENSE.md',
     ]),
     ('cherrypy/process', []),
     ('cherrypy/scaffold', [


### PR DESCRIPTION
The first commit fixes the issue with TypeError being swallowed by decorated handlers.
The other two commits are required in order to run the test suite correctly.