### PR TITLE
Popargs documentation: Use matching parameter name

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -185,7 +185,7 @@ understand the structure of your URL.
 This works similarly to `_cp_dispatch` but, as said above, is more
 explicit and localized. It says:
 
-- take the first segment and store it into a parameter name `band`
+- take the first segment and store it into a parameter name `name`
 - take again the first segment (since we removed the previous first) 
   and store it into a parameter named `title`
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -185,7 +185,7 @@ understand the structure of your URL.
 This works similarly to `_cp_dispatch` but, as said above, is more
 explicit and localized. It says:
 
-- take the first segment and store it into a parameter name `name`
+- take the first segment and store it into a parameter named `name`
 - take again the first segment (since we removed the previous first) 
   and store it into a parameter named `title`
 


### PR DESCRIPTION
The explanation for that piece of sample code below it refers to the parameter which represents the band name as "band", whereas the code uses "name".  We change the code to use "band" as well.

This also fixes a typo in the same explanation.