### PR TITLE
Simpler data file handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@
     include: cherrypy/test/
     args:
     - '--django'
+    exclude: tests/dist-check.py
   - id: debug-statements
   - id: check-added-large-files
   - id: check-ast

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
   include:
     - python: 3.5
       env: TOXENV=linter
+  include:
+    - python: 3.5
+      env: TOXENV=dist-check
 
 cache: pip
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import sys
 import io
-from distutils.command.install import INSTALL_SCHEMES
 
 import setuptools
 
@@ -60,35 +59,6 @@ packages = [
     'cherrypy.scaffold',
     'cherrypy.wsgiserver',
 ]
-data_files = [
-    ('cherrypy', [
-        'cherrypy/cherryd',
-        'cherrypy/favicon.ico',
-        'LICENSE.md',
-    ]),
-    ('cherrypy/process', []),
-    ('cherrypy/scaffold', [
-        'cherrypy/scaffold/example.conf',
-        'cherrypy/scaffold/site.conf',
-    ]),
-    ('cherrypy/scaffold/static', [
-        'cherrypy/scaffold/static/made_with_cherrypy_small.png',
-    ]),
-    ('cherrypy/test', [
-        'cherrypy/test/style.css',
-        'cherrypy/test/test.pem',
-    ]),
-    ('cherrypy/test/static', [
-        'cherrypy/test/static/index.html',
-        'cherrypy/test/static/dirback.jpg',
-    ]),
-    ('cherrypy/tutorial', [
-        'cherrypy/tutorial/tutorial.conf',
-        'cherrypy/tutorial/README.txt',
-        'cherrypy/tutorial/pdf_file.pdf',
-        'cherrypy/tutorial/custom_error.html',
-    ]),
-]
 scripts = ['cherrypy/cherryd']
 
 install_requires = [
@@ -126,13 +96,6 @@ extras_require = {
 # end arguments for setup
 ###############################################################################
 
-# wininst may install data_files in Python/x.y instead of the cherrypy package.
-# Django's solution is at http://code.djangoproject.com/changeset/8313
-# See also
-# http://mail.python.org/pipermail/distutils-sig/2004-August/004134.html
-if 'bdist_wininst' in sys.argv or '--format=wininst' in sys.argv:
-    data_files = [(r'\PURELIB\%s' % path, files) for path, files in data_files]
-
 setup_params = dict(
     name=name,
     use_scm_version=True,
@@ -144,8 +107,8 @@ setup_params = dict(
     url=url,
     license=cp_license,
     packages=packages,
-    data_files=data_files,
     scripts=scripts,
+    include_package_data=True,
     install_requires=install_requires,
     extras_require=extras_require,
     setup_requires=[
@@ -156,11 +119,6 @@ setup_params = dict(
 
 
 def main():
-    # set default location for "data_files" to
-    # platform specific "site-packages" location
-    for scheme in list(INSTALL_SCHEMES.values()):
-        scheme['data'] = scheme['purelib']
-
     setuptools.setup(**setup_params)
 
 

--- a/tests/dist-check.py
+++ b/tests/dist-check.py
@@ -5,6 +5,7 @@ import pytest
 
 
 @pytest.fixture(params=[
+    'favicon.ico',
     'scaffold/static/made_with_cherrypy_small.png',
     'tutorial/tutorial.conf',
     'tutorial/custom_error.html',

--- a/tests/dist-check.py
+++ b/tests/dist-check.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture(params=[
+    'scaffold/static/made_with_cherrypy_small.png',
+    'tutorial/tutorial.conf',
+    'tutorial/custom_error.html',
+])
+def data_file_path(request):
+    return request.param
+
+
+@pytest.fixture(autouse=True, scope="session")
+def remove_sys_path_0():
+    "pytest adds cwd to sys.path[0]"
+    print("removing", sys.path[0])
+    del sys.path[0]
+    assert 'cherrypy' not in sys.modules
+
+
+def test_data_files_installed(data_file_path):
+    import cherrypy
+    root = os.path.dirname(cherrypy.__file__)
+    fn = os.path.join(root, data_file_path)
+    assert os.path.exists(fn), fn
+    # make sure the file isn't in the local checkout
+    assert not os.path.samefile(fn, os.path.join('cherrypy', data_file_path))
+
+
+def test_sanity():
+    with pytest.raises(Exception):
+        test_data_files_installed('does not exist')

--- a/tests/dist-check.py
+++ b/tests/dist-check.py
@@ -1,3 +1,17 @@
+"""
+Integration test to check the integrity of the
+distribution.
+
+This file is explicitly not named 'test_' to avoid
+being collected by pytest, but must instead be
+invoked explicitly (i.e. pytest tests/dist-check.py).
+
+This test cannot be invoked as part of the normal
+test suite nor can it be included in the normal test
+suite because it must import cherrypy late (after
+removing sys.path[0]).
+"""
+
 import os
 import sys
 
@@ -11,6 +25,7 @@ import pytest
     'tutorial/custom_error.html',
 ])
 def data_file_path(request):
+    "generates data file paths expected to be found in the package"
     return request.param
 
 
@@ -23,6 +38,10 @@ def remove_sys_path_0():
 
 
 def test_data_files_installed(data_file_path):
+    """
+    Ensure that data file paths are available in the
+    installed package as expected.
+    """
     import cherrypy
     root = os.path.dirname(cherrypy.__file__)
     fn = os.path.join(root, data_file_path)
@@ -32,5 +51,9 @@ def test_data_files_installed(data_file_path):
 
 
 def test_sanity():
+    """
+    Test the test to show that it does fail when a file
+    is missing.
+    """
     with pytest.raises(Exception):
         test_data_files_installed('does not exist')

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,9 @@ extras =
 [testenv:linter]
 deps = pre-commit
 commands = pre-commit run --all-files {posargs}
+
+[testenv:dist-check]
+# ensure that package artifacts are installed as expected
+usedevelop = False
+commands =
+    pytest tests/dist-check.py {posargs}


### PR DESCRIPTION
While investigating the purpose behind the `data_files` directive in `setup.py`, I encountered #1538 and #1090. I believe this patch, by dropping custom handling of data files and relying on the tried-and-true techniques for including package data, should fix both of these issues and lessen the debt on the project.

One subtle effect of this change that I want to highlight - the LICENSE.md file will no longer get implicitly copied into the package. I don't believe that's necessary or if it is, it can be handled separately.