### PR TITLE
Skip tests that require writing unicode filenames on incompatible filesystems.

### DIFF
--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -17,6 +17,17 @@ from cherrypy._cpcompat import (
 from cherrypy.test import helper
 
 
+@pytest.fixture
+def unicode_filesystem(tmpdir):
+    filename = tmpdir / ntou('☃', 'utf-8')
+    tmpl = "File system encoding ({encoding}) cannot support unicode filenames"
+    msg = tmpl.format(encoding=sys.getfilesystemencoding())
+    try:
+        io.open(filename, 'w')
+    except UnicodeEncodeError:
+        pytest.skip(reason=msg)
+
+
 curdir = os.path.join(os.getcwd(), os.path.dirname(__file__))
 has_space_filepath = os.path.join(curdir, 'static', 'has space.html')
 bigfile_filepath = os.path.join(curdir, 'static', 'bigfile.log')
@@ -375,7 +386,7 @@ class StaticTest(helper.CPWebCase):
         sys.version_info < (3,)
     )
     @pytest.mark.xfail(py27_on_windows, reason="#1544")
-    def test_unicode(self):
+    def test_unicode(self, unicode_filesystem):
         with self.unicode_file():
             url = ntou('/static/Слава Україні.html', 'utf-8')
             # quote function requires str

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -6,7 +6,7 @@ import sys
 import platform
 import tempfile
 
-import six
+from six import text_type as str
 from six.moves import urllib
 
 import pytest
@@ -26,7 +26,7 @@ def unicode_filesystem(tmpdir):
     tmpl = "File system encoding ({encoding}) cannot support unicode filenames"
     msg = tmpl.format(encoding=sys.getfilesystemencoding())
     try:
-        io.open(six.text_type(filename), 'w')
+        io.open(str(filename), 'w')
     except UnicodeEncodeError:
         pytest.skip(msg)
 
@@ -400,7 +400,7 @@ class StaticTest(helper.CPWebCase):
 
             expected = ntou('Героям Слава!', 'utf-8')
             self.assertInBody(expected)
-    
+
     def ensure_unicode_filesystem(self):
         """
         TODO: replace with simply pytest fixtures once webtest.TestCase

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -26,7 +26,7 @@ def unicode_filesystem(tmpdir):
     tmpl = "File system encoding ({encoding}) cannot support unicode filenames"
     msg = tmpl.format(encoding=sys.getfilesystemencoding())
     try:
-        io.open(str(filename), 'w')
+        io.open(str(filename), 'w').close()
     except UnicodeEncodeError:
         pytest.skip(msg)
 

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -31,6 +31,18 @@ def unicode_filesystem(tmpdir):
         pytest.skip(msg)
 
 
+def ensure_unicode_filesystem():
+    """
+    TODO: replace with simply pytest fixtures once webtest.TestCase
+    no longer implies unittest.
+    """
+    tmpdir = py.path.local(tempfile.mkdtemp())
+    try:
+        unicode_filesystem(tmpdir)
+    finally:
+        tmpdir.remove()
+
+
 curdir = os.path.join(os.getcwd(), os.path.dirname(__file__))
 has_space_filepath = os.path.join(curdir, 'static', 'has space.html')
 bigfile_filepath = os.path.join(curdir, 'static', 'bigfile.log')
@@ -390,7 +402,7 @@ class StaticTest(helper.CPWebCase):
     )
     @pytest.mark.xfail(py27_on_windows, reason="#1544")
     def test_unicode(self):
-        self.ensure_unicode_filesystem()
+        ensure_unicode_filesystem()
         with self.unicode_file():
             url = ntou('/static/Слава Україні.html', 'utf-8')
             # quote function requires str
@@ -400,17 +412,6 @@ class StaticTest(helper.CPWebCase):
 
             expected = ntou('Героям Слава!', 'utf-8')
             self.assertInBody(expected)
-
-    def ensure_unicode_filesystem(self):
-        """
-        TODO: replace with simply pytest fixtures once webtest.TestCase
-        no longer implies unittest.
-        """
-        tmpdir = py.path.local(tempfile.mkdtemp())
-        try:
-            unicode_filesystem(tmpdir)
-        finally:
-            tmpdir.remove()
 
 
 def error_page_404(status, message, traceback, version):


### PR DESCRIPTION
Fixes #1567