### PR TITLE
Fix missing import

### DIFF
--- a/cherrypy/lib/reprconf.py
+++ b/cherrypy/lib/reprconf.py
@@ -18,6 +18,8 @@ by adding a named handler to Config.namespaces. The name can be any string,
 and the handler must be either a callable or a context manager.
 """
 
+from cherrypy._cpcompat import text_or_bytes
+
 try:
     # Python 3.0+
     from configparser import ConfigParser


### PR DESCRIPTION
`text_or_bytes` is never defined, so a NameError is always raised. 
So it is always set to `str`, which causes a problem in functions like this, where a `unicode` is not recognized as string:
```py
    def update(self, config):
        """Update self from a dict, file or filename."""
        if isinstance(config, text_or_bytes):
            # Filename
            config = Parser().dict_from_file(config)
        elif hasattr(config, 'read'):
            # Open file object
            config = Parser().dict_from_file(config)
        else:
            config = config.copy()
        self._apply(config)
```
