### PR TITLE
Windows causes timeout during port check

### DIFF
--- a/cherrypy/process/servers.py
+++ b/cherrypy/process/servers.py
@@ -250,7 +250,7 @@ class ServerAdapter(object):
         if not os.environ.get('LISTEN_PID', None):
             # Wait for port to be occupied if not running via socket-activation
             # (for socket-activation the port will be managed by systemd )
-            if isinstance(self.bind_addr, tuple):
+            if isinstance(self.bind_addr, tuple) and os.name != 'nt':
                 with _safe_wait(*self.bound_addr):
                     portend.occupied(*self.bound_addr, timeout=Timeouts.occupied)
 


### PR DESCRIPTION
During startup port checking always results in a timeout on Windows. This just skips the check if the system is a windows system.

Currently it checks until timeout and adds time to startup unnecessarily.