### PR TITLE
Python 3.6 invalid escape sequence deprecation fixes

### DIFF
--- a/cherrypy/_cpreqbody.py
+++ b/cherrypy/_cpreqbody.py
@@ -328,7 +328,7 @@ class Entity(object):
     # absence of a charset parameter, is US-ASCII."
     # However, many browsers send data in utf-8 with no charset.
     attempt_charsets = ['utf-8']
-    """A list of strings, each of which should be a known encoding.
+    r"""A list of strings, each of which should be a known encoding.
 
     When the Content-Type of the request body warrants it, each of the given
     encodings will be tried in order. The first one to successfully decode the
@@ -577,7 +577,7 @@ class Part(Entity):
     # "The default character set, which must be assumed in the absence of a
     # charset parameter, is US-ASCII."
     attempt_charsets = ['us-ascii', 'utf-8']
-    """A list of strings, each of which should be a known encoding.
+    r"""A list of strings, each of which should be a known encoding.
 
     When the Content-Type of the request body warrants it, each of the given
     encodings will be tried in order. The first one to successfully decode the

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -42,7 +42,7 @@ HTTPDate = functools.partial(email.utils.formatdate, usegmt=True)
 
 
 def urljoin(*atoms):
-    """Return the given path \*atoms, joined into a single URL.
+    r"""Return the given path \*atoms, joined into a single URL.
 
     This will correctly join a SCRIPT_NAME and PATH_INFO into the
     original URL, even if either atom is blank.

--- a/cherrypy/process/servers.py
+++ b/cherrypy/process/servers.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Starting in CherryPy 3.1, cherrypy.server is implemented as an
 :ref:`Engine Plugin<plugins>`. It's an instance of
 :class:`cherrypy._cpserver.Server`, which is a subclass of

--- a/cherrypy/process/wspbus.py
+++ b/cherrypy/process/wspbus.py
@@ -1,4 +1,4 @@
-"""An implementation of the Web Site Process Bus.
+r"""An implementation of the Web Site Process Bus.
 
 This module is completely standalone, depending only on the stdlib.
 

--- a/cherrypy/test/helper.py
+++ b/cherrypy/test/helper.py
@@ -457,7 +457,7 @@ server.ssl_private_key: r'%s'
             '-c', self.config_file,
             '-p', self.pid_file,
         ]
-        """
+        r"""
         Command for running cherryd server with autoreload enabled
 
         Using

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -215,13 +215,13 @@ class StaticTest(helper.CPWebCase):
         self.assertErrorPage(500)
         if sys.version_info >= (3, 3):
             errmsg = (
-                'TypeError: staticdir\(\) missing 2 '
+                r'TypeError: staticdir\(\) missing 2 '
                 'required positional arguments'
             )
         else:
             errmsg = (
-                'TypeError: staticdir\(\) takes at least 2 '
-                '(positional )?arguments \(0 given\)'
+                r'TypeError: staticdir\(\) takes at least 2 '
+                r'(positional )?arguments \(0 given\)'
             )
         self.assertMatchesBody(errmsg.encode('ascii'))
 


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior
