### PR TITLE
Added note to docs about sessions when more than one app is on a single domain.

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -57,6 +57,17 @@ However, CherryPy "recognizes" a session id by looking up the saved session
 data for that id. Therefore, if you never save any session data,
 **you will get a new session id for every request**.
 
+A side effect of CherryPy overwriting unrecognised session ids is that if you
+have multiple, separate CherryPy applications running on a single domain (e.g.
+on different ports), each app will overwrite the other's session id because by
+default they use the same cookie name (``"session_id"``) but do not recognise
+each others sessions. It is therefore a good idea to use a different name for
+each, for example::
+
+    [/]
+    ...
+    tools.sessions.name = "my_app_session_id"
+
 ================
 Sharing Sessions
 ================


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Updates documentation on sessions.

* **What is the related issue number (starting with `#`)**

N/A - No bug report.

* **What is the current behavior?** (You can also link to an open issue here)

Currently documentation does not mention the existence of the config property tools.sessions.name. This is a useful tool if two separate applications are in the same cookie context.

* **What is the new behavior (if this is a feature change)?**

Documention now mentions the config property and how it can help in the above case.

* **Other information**:

See also my answer on StackOverflow: https://stackoverflow.com/questions/2597024/cherrypy-sessions-for-same-domain-different-port/45065890#45065890