### PR TITLE
Only skip problematic section of query_string_decoding

### DIFF
--- a/cherrypy/test/test_encoding.py
+++ b/cherrypy/test/test_encoding.py
@@ -120,12 +120,11 @@ class EncodingTests(helper.CPWebCase):
         cherrypy.tree.mount(root, config={'/gzip': {'tools.gzip.on': True}})
 
     def test_query_string_decoding(self):
-        if six.PY3:
-            # This test fails on Python 3. See #1443
-            return
-        europoundUtf8 = europoundUnicode.encode('utf-8')
-        self.getPage(ntob('/?param=') + europoundUtf8)
-        self.assertBody(europoundUtf8)
+        if six.PY2:
+            # URLs with unicode are no longer supported in Py3 urllib. See #1443
+            europoundUtf8 = europoundUnicode.encode('utf-8')
+            self.getPage(ntob('/?param=') + europoundUtf8)
+            self.assertBody(europoundUtf8)
 
         # Encoded utf8 query strings MUST be parsed correctly.
         # Here, q is the POUND SIGN U+00A3 encoded in utf8 and then %HEX


### PR DESCRIPTION
This style of URL is simply no longer supported by urllib, so it breaks this test in Py3

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Revives test with only the problematic part skipped

* **What is the related issue number (starting with `#`)**
#1443


* **What is the current behavior?** (You can also link to an open issue here)
Skips the entire test

* **What is the new behavior (if this is a feature change)?**
Skips check of unsupported behavior, runs rest of test

* **Other information**:
This is just one possible solution, open to suggestions