### PR TITLE
Fix gzip and caching tools integration (#1190)

### DIFF
--- a/cherrypy/_cptools.py
+++ b/cherrypy/_cptools.py
@@ -411,8 +411,8 @@ class CachingTool(Tool):
             if request.cacheable:
                 # Note the devious technique here of adding hooks on the fly
                 request.hooks.attach('before_finalize', _caching.tee_output,
-                                     priority=90)
-    _wrapper.priority = 20
+                                     priority=100)
+    _wrapper.priority = 90
 
     def _setup(self):
         """Hook caching into cherrypy.request."""

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -411,7 +411,9 @@ def tee_output():
                              body, response.time), len(body))
 
     response = cherrypy.serving.response
-    tee(response.body)
+    tee_gen = tee(response.body)
+    if tee_gen:
+        response.body = tee_gen
 
 
 def expires(secs=0, force=False, debug=False):

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -344,7 +344,7 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
                 return False
 
         if debug:
-            cherrypy.log('Reading response from cache', 'TOOLS.CACHING') 
+            cherrypy.log('Reading response from cache', 'TOOLS.CACHING')
         s, h, b, create_time = cache_data
         age = int(response.time - create_time)
         if (age > max_age):

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -344,8 +344,7 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
                 return False
 
         if debug:
-            cherrypy.log('Reading response from cache', 'TOOLS.CACHING')
-        
+            cherrypy.log('Reading response from cache', 'TOOLS.CACHING') 
         s, h, b, create_time = cache_data
         age = int(response.time - create_time)
         if (age > max_age):
@@ -413,6 +412,7 @@ def tee_output():
 
     response = cherrypy.serving.response
     response.body = tee(response.body)
+
 
 def expires(secs=0, force=False, debug=False):
     """Tool for influencing cache mechanisms using the 'Expires' header.

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -346,12 +346,13 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
         if debug:
             cherrypy.log('Reading response from cache', 'TOOLS.CACHING')
         s, h, b, create_time = cache_data
-        if h.get('Content-Encoding') == 'gzip' and ntob(b[0:2]) != ntob('\x1f\x8b'):
+        if h.get('Content-Encoding') == 'gzip' and b[0:2] != ntob('\x1f\x8b'):
             # In some cases, a request will be cached, have its Content-Encoding header
             # set to 'gzip', but is not actually gzipped. We check this scenario here,
             # invalidate any cache entries, and force encoding.gzip to run.
             cherrypy._cache.delete()
             response.headers.pop('Content-Length', None)
+            response.headers.pop('Content-Encoding', None)
             request.cached = False
             request.cacheable = True
             return False

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -345,17 +345,8 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
 
         if debug:
             cherrypy.log('Reading response from cache', 'TOOLS.CACHING')
+        
         s, h, b, create_time = cache_data
-        if h.get('Content-Encoding') == 'gzip' and b[0:2] != ntob('\x1f\x8b'):
-            # In some cases, a request will be cached, have its Content-Encoding header
-            # set to 'gzip', but is not actually gzipped. We check this scenario here,
-            # invalidate any cache entries, and force encoding.gzip to run.
-            cherrypy._cache.delete()
-            response.headers.pop('Content-Length', None)
-            response.headers.pop('Content-Encoding', None)
-            request.cached = False
-            request.cacheable = True
-            return False
         age = int(response.time - create_time)
         if (age > max_age):
             if debug:

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -346,9 +346,9 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
         if debug:
             cherrypy.log('Reading response from cache', 'TOOLS.CACHING')
         s, h, b, create_time = cache_data
-        if h.get('Content-Encoding') == 'gzip' and b[0:2] != '\x1f\x8b':
-            # In some cases, a request will be cached, have its Content-Encoding header 
-            # set to 'gzip', but not actually gzipped. We check this scenario here,
+        if h.get('Content-Encoding') == 'gzip' and ntob(b[0:2]) != ntob('\x1f\x8b'):
+            # In some cases, a request will be cached, have its Content-Encoding header
+            # set to 'gzip', but is not actually gzipped. We check this scenario here,
             # invalidate any cache entries, and force encoding.gzip to run.
             cherrypy._cache.delete()
             response.headers.pop('Content-Length', None)

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -411,7 +411,7 @@ def tee_output():
                              body, response.time), len(body))
 
     response = cherrypy.serving.response
-    response.body = tee(response.body)
+    tee(response.body)
 
 
 def expires(secs=0, force=False, debug=False):

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -352,7 +352,6 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
             # invalidate any cache entries, and force encoding.gzip to run.
             cherrypy._cache.delete()
             response.headers.pop('Content-Length', None)
-            response.headers.pop('Content-Encoding', None)
             request.cached = False
             request.cacheable = True
             return False

--- a/cherrypy/test/test_caching.py
+++ b/cherrypy/test/test_caching.py
@@ -285,37 +285,37 @@ class CacheTest(helper.CPWebCase):
         if cherrypy.server.protocol_version == 'HTTP/1.1':
             self.assertHeader('Cache-Control', 'no-cache, must-revalidate')
         self.assertHeader('Expires', 'Sun, 28 Jan 2007 00:00:00 GMT')
-        
+
     def testGzipStaticCache(self):
         headers = [('Accept-Encoding', 'gzip')]
         idx_uri = '/gzip_static_cache/index.html'
         jpg_uri = '/gzip_static_cache/dirback.jpg'
-        
+
         self.getPage(idx_uri, method='GET', headers=headers)
         idx_resp_headers = dict(self.headers)
         idx_gz_content_len = idx_resp_headers['Content-Length']
-        
+
         self.getPage(jpg_uri, method='GET', headers=headers)
         jpg_resp_headers = dict(self.headers)
         jpg_gz_content_len = jpg_resp_headers['Content-Length']
-        
+
         for _ in range(3):
             self.getPage(idx_uri, method='GET', headers=headers)
             # all requests should get the same length
             self.assertHeader('Content-Length', idx_gz_content_len)
             self.assertHeader('Content-Encoding', 'gzip')
-        
+
         for _ in range(3):
             self.getPage(jpg_uri, method='GET', headers=headers)
             self.assertHeader('Content-Length', jpg_gz_content_len)
             self.assertHeader('Content-Encoding', 'gzip')
-            
+
         # check that we can still get non-gzipped version
         self.getPage(idx_uri, method='GET')
         self.assertNoHeader('Content-Encoding')
         # non-gzipped version should have a different content length
         self.assertNoHeaderItemValue('Content-Length', idx_gz_content_len)
-        
+
         self.getPage(jpg_uri, method='GET')
         self.assertNoHeader('Content-Encoding')
         self.assertNoHeaderItemValue('Content-Length', jpg_gz_content_len)

--- a/cherrypy/test/test_caching.py
+++ b/cherrypy/test/test_caching.py
@@ -137,9 +137,7 @@ class CacheTest(helper.CPWebCase):
             'tools.staticdir.root': curdir
         })
         class GzipStaticCache(object):
-            @cherrypy.expose
-            def dummy(self):
-                return ''
+            pass
 
         cherrypy.tree.mount(Root())
         cherrypy.tree.mount(UnCached(), '/expires')
@@ -287,6 +285,7 @@ class CacheTest(helper.CPWebCase):
         self.assertHeader('Expires', 'Sun, 28 Jan 2007 00:00:00 GMT')
 
     def testGzipStaticCache(self):
+        """Tests Github issue #1190"""
         headers = [('Accept-Encoding', 'gzip')]
         idx_uri = '/gzip_static_cache/index.html'
         jpg_uri = '/gzip_static_cache/dirback.jpg'
@@ -299,13 +298,13 @@ class CacheTest(helper.CPWebCase):
         jpg_resp_headers = dict(self.headers)
         jpg_gz_content_len = jpg_resp_headers['Content-Length']
 
-        for _ in range(3):
+        for _ in range(2):
             self.getPage(idx_uri, method='GET', headers=headers)
             # all requests should get the same length
             self.assertHeader('Content-Length', idx_gz_content_len)
             self.assertHeader('Content-Encoding', 'gzip')
 
-        for _ in range(3):
+        for _ in range(2):
             self.getPage(jpg_uri, method='GET', headers=headers)
             self.assertHeader('Content-Length', jpg_gz_content_len)
             self.assertHeader('Content-Encoding', 'gzip')

--- a/cherrypy/test/test_caching.py
+++ b/cherrypy/test/test_caching.py
@@ -135,12 +135,11 @@ class CacheTest(helper.CPWebCase):
             'tools.staticdir.on': True,
             'tools.staticdir.dir': 'static',
             'tools.staticdir.root': curdir
-            
         })
         class GzipStaticCache(object):
             @cherrypy.expose
             def dummy(self):
-                return ""
+                return ''
 
         cherrypy.tree.mount(Root())
         cherrypy.tree.mount(UnCached(), '/expires')

--- a/cherrypy/test/webtest.py
+++ b/cherrypy/test/webtest.py
@@ -425,7 +425,7 @@ class WebCase(unittest.TestCase):
             if msg is None:
                 msg = '%r in headers' % key
             self._handlewebError(msg)
-            
+
     def assertNoHeaderItemValue(self, key, value, msg=None):
         """Fail if the header contains the specified value"""
         lowkey = key.lower()

--- a/cherrypy/test/webtest.py
+++ b/cherrypy/test/webtest.py
@@ -425,6 +425,16 @@ class WebCase(unittest.TestCase):
             if msg is None:
                 msg = '%r in headers' % key
             self._handlewebError(msg)
+            
+    def assertNoHeaderItemValue(self, key, value, msg=None):
+        """Fail if the header contains the specified value"""
+        lowkey = key.lower()
+        hdrs = self.headers
+        matches = [k for k, v in hdrs if k.lower() == lowkey and v == value]
+        if matches:
+            if msg is None:
+                msg = '%r:%r in %r' % (key, value, hdrs)
+            self._handlewebError(msg)
 
     def assertBody(self, value, msg=None):
         """Fail if value != self.body."""


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes an issue where an initial page load (when having both gzip and caching enabled) may cause a content decode error. Subsequent page loads work correctly.

* **What is the related issue number (starting with `#`)**

#1190

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/cherrypy/cherrypy/issues/1190

* **What is the new behavior (if this is a feature change)?**


* **Other information**:
