### PR TITLE
File in sub-dir of staticdir in long-path notation would not load

### DIFF
--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -314,6 +314,13 @@ def staticdir(section, dir, root='', match='', content_types=None, index='',
     branch = request.path_info[len(section) + 1:]
     branch = urllib.parse.unquote(branch.lstrip(r'\/'))
 
+    # On Windows requesting a file in sub-dir of the staticdir results
+    # in mixing of delimiter styles, eg: C:\static\js/script.js
+    # Python normally converts this but not when the staticdir is
+    # supplied in long-path notation, eg: \\?\C:\static\js/script.js
+    if os.name == 'nt':
+        branch = branch.replace('/', '\\')
+
     # If branch is "", filename will end in a slash
     filename = os.path.join(dir, branch)
     if debug:

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -111,6 +111,10 @@ class StaticTest(helper.CPWebCase):
                 'tools.staticdir.dir': 'static',
                 'tools.staticdir.root': curdir,
             },
+            '/static-long': {
+                'tools.staticdir.on': True,
+                'tools.staticdir.dir': r'\\?\%s' % curdir,
+            },
             '/style.css': {
                 'tools.staticfile.on': True,
                 'tools.staticfile.filename': os.path.join(curdir, 'style.css'),
@@ -184,6 +188,14 @@ class StaticTest(helper.CPWebCase):
         #   into \r\n on Windows when extracting the CherryPy tarball so
         #   we just check the content
         self.assertMatchesBody('^Dummy stylesheet')
+
+    @pytest.mark.skipif(platform.system() != 'Windows', reason='Windows only')
+    def test_static_longpath(self):
+        """Test serving of a file in subdir of a Windows long-path staticdir."""
+        self.getPage('/static-long/static/index.html')
+        self.assertStatus('200 OK')
+        self.assertHeader('Content-Type', 'text/html')
+        self.assertBody('Hello, world\r\n')
 
     def test_fallthrough(self):
         # Test that NotFound will then try dynamic handlers (see [878]).


### PR DESCRIPTION
If a `staticdir` is supplied in Windows long-path notation, serving a file from a subdirectory would fail because `os.stat` does not like the mixing of forward and backwards slashes.
Tested on both Python 2.7.14 and 3.6.2.

In the included test the old behavior would be to do:
```python
os.stat('\\?\C:\cherrypy\static/index.html')
```
Which fails due to the mixed slashes, resulting in a 404.