### PR TITLE
Added uuidv4 and now() in RFC3339 UTC Format

### DIFF
--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -262,7 +262,7 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
-                 'i': str(response.uuid),
+                 'i': request.unique_id,
                  'z': LazyRfc3339UtcTime(),
                  }
         if six.PY3:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -314,6 +314,7 @@ class LogManager(object):
         month = monthnames[now.month - 1].capitalize()
         return ('[%02d/%s/%04d:%02d:%02d:%02d]' %
                 (now.day, month, now.year, now.hour, now.minute, now.second))
+                
     @staticmethod
     def time_z(self):
         """Return now() in RFC3339 UTC Format."""

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -138,6 +138,7 @@ class NullHandler(logging.Handler):
     def createLock(self):
         self.lock = None
 
+
 class GetUuid(object):
     def __init__(self):
         self._uuid = None
@@ -147,6 +148,7 @@ class GetUuid(object):
         if self._uuid is None:
             self._uuid = uuid.uuid4()
         return self._uuid
+
 
 class LogManager(object):
 

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -113,7 +113,6 @@ import os
 import sys
 
 import six
-import uuid
 
 import cherrypy
 from cherrypy import _cperror
@@ -252,7 +251,6 @@ class LogManager(object):
             status = response.output_status.split(ntob(' '), 1)[0]
             if six.PY3:
                 status = status.decode('ISO-8859-1')
-
         atoms = {'h': remote.name or remote.ip,
                  'l': '-',
                  'u': getattr(request, 'login', None) or '-',
@@ -263,7 +261,7 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
-                 'i': str(uuid.uuid4()),
+                 'i': response.uuid,
                  'z': self.time_z(),
                  }
         if six.PY3:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -111,10 +111,12 @@ import datetime
 import logging
 import os
 import sys
+
+import six
 import uuid
 
 import cherrypy
-import six
+
 from cherrypy import _cperror
 from cherrypy._cpcompat import ntob
 
@@ -215,8 +217,7 @@ class LogManager(object):
         if traceback:
             exc_info = _cperror._exc_info()
 
-        self.error_log.log(severity, ' '.join(
-            (self.time(), context, msg)), exc_info=exc_info)
+        self.error_log.log(severity, ' '.join((self.time(), context, msg)), exc_info=exc_info)
 
     def __call__(self, *args, **kwargs):
         """An alias for ``error``."""

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -317,7 +317,7 @@ class LogManager(object):
     def time_z(self):
         """Return now() in RFC3339 UTC Format."""
         now = datetime.datetime.now()
-        return now.isoformat("T") + "Z"
+        return now.isoformat('T') + 'Z'
 
     def _get_builtin_handler(self, log, key):
         for h in log.handlers:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -314,7 +314,7 @@ class LogManager(object):
         month = monthnames[now.month - 1].capitalize()
         return ('[%02d/%s/%04d:%02d:%02d:%02d]' %
                 (now.day, month, now.year, now.hour, now.minute, now.second))
-
+    @staticmethod
     def time_z(self):
         """Return now() in RFC3339 UTC Format."""
         now = datetime.datetime.now()

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -119,6 +119,7 @@ import cherrypy
 from cherrypy import _cperror
 from cherrypy._cpcompat import ntob
 
+
 # Silence the no-handlers "warning" (stderr write!) in stdlib logging
 logging.Logger.manager.emittedNoHandlerWarning = 1
 logfmt = logging.Formatter('%(message)s')

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -251,7 +251,7 @@ class LogManager(object):
             status = response.output_status.split(ntob(' '), 1)[0]
             if six.PY3:
                 status = status.decode('ISO-8859-1')
-                
+
         atoms = {'h': remote.name or remote.ip,
                  'l': '-',
                  'u': getattr(request, 'login', None) or '-',

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -262,7 +262,7 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
-                 '4': uuid.uuid4(),
+                 'i': str(uuid.uuid4()),
                  'z': self.time_z(),
                  }
         if six.PY3:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -262,7 +262,7 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
-                 'i': response.uuid,
+                 'i': str(response.uuid),
                  'z': self.time_z(),
                  }
         if six.PY3:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -113,7 +113,6 @@ import os
 import sys
 
 import six
-import uuid
 
 import cherrypy
 from cherrypy import _cperror
@@ -137,17 +136,6 @@ class NullHandler(logging.Handler):
 
     def createLock(self):
         self.lock = None
-
-
-class GetUuid(object):
-    def __init__(self):
-        self._uuid = None
-
-    @property
-    def get_uuid(self):
-        if self._uuid is None:
-            self._uuid = uuid.uuid4()
-        return self._uuid
 
 
 class LogManager(object):
@@ -257,7 +245,6 @@ class LogManager(object):
         response = cherrypy.serving.response
         outheaders = response.headers
         inheaders = request.headers
-        request_uid = GetUuid()
         if response.output_status is None:
             status = '-'
         else:
@@ -275,7 +262,7 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
-                 'i': request_uid.get_uuid(),
+                 'i': request.uuid,
                  'z': self.time_z(),
                  }
         if six.PY3:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -138,39 +138,15 @@ class NullHandler(logging.Handler):
     def createLock(self):
         self.lock = None
 
+class GetUuid(object):
+    def __init__(self):
+        self._uuid = None
 
-class CachedUuid(object):
-    def __init__(self, wrapped):
-        self.wrapped = wrapped
-        try:
-            self.__doc__ = wrapped.__doc__
-        except:  # pragma: no cover
-            pass
-
-    # original sets the attributes on the instance
-    # def __get__(self, inst, objtype=None):
-    #    if inst is None:
-    #        return self
-    #    val = self.wrapped(inst)
-    #    setattr(inst, self.wrapped.__name__, val)
-    #    return val
-
-    # ignore the instance, and just set them on the class
-    # if called on a class, inst is None and objtype is the class
-    # if called on an instance, inst is the instance, and objtype
-    # the class
-    def __get__(self, inst, objtype=None):
-        # ask the value from the wrapped object, giving it
-        # our class
-        val = self.wrapped(objtype)
-
-        # and set the attribute directly to the class, thereby
-        # avoiding the descriptor to be called multiple times
-        setattr(objtype, self.wrapped.__name__, val)
-
-        # and return the calculated value
-        return val
-
+    @property
+    def get_uuid(self):
+        if self._uuid is None:
+            self._uuid = uuid.uuid4()
+        return self._uuid
 
 class LogManager(object):
 
@@ -279,6 +255,7 @@ class LogManager(object):
         response = cherrypy.serving.response
         outheaders = response.headers
         inheaders = request.headers
+        request_uid = GetUuid()
         if response.output_status is None:
             status = '-'
         else:
@@ -296,7 +273,7 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
-                 'i': self.get_uuid(),
+                 'i': request_uid.get_uuid(),
                  'z': self.time_z(),
                  }
         if six.PY3:
@@ -353,10 +330,6 @@ class LogManager(object):
         """Return now() in RFC3339 UTC Format."""
         now = datetime.datetime.now()
         return now.isoformat('T') + 'Z'
-    
-    @CachedUuid
-    def get_uuid(cls):
-        return uuid.uuid4()
 
     def _get_builtin_handler(self, log, key):
         for h in log.handlers:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -116,7 +116,6 @@ import six
 import uuid
 
 import cherrypy
-
 from cherrypy import _cperror
 from cherrypy._cpcompat import ntob
 

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -111,13 +111,12 @@ import datetime
 import logging
 import os
 import sys
-
-import six
+import uuid
 
 import cherrypy
+import six
 from cherrypy import _cperror
 from cherrypy._cpcompat import ntob
-
 
 # Silence the no-handlers "warning" (stderr write!) in stdlib logging
 logging.Logger.manager.emittedNoHandlerWarning = 1
@@ -216,7 +215,8 @@ class LogManager(object):
         if traceback:
             exc_info = _cperror._exc_info()
 
-        self.error_log.log(severity, ' '.join((self.time(), context, msg)), exc_info=exc_info)
+        self.error_log.log(severity, ' '.join(
+            (self.time(), context, msg)), exc_info=exc_info)
 
     def __call__(self, *args, **kwargs):
         """An alias for ``error``."""
@@ -262,6 +262,8 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
+                 '4': uuid.uuid4(),
+                 'z': self.time_z(),
                  }
         if six.PY3:
             for k, v in atoms.items():
@@ -311,6 +313,11 @@ class LogManager(object):
         month = monthnames[now.month - 1].capitalize()
         return ('[%02d/%s/%04d:%02d:%02d:%02d]' %
                 (now.day, month, now.year, now.hour, now.minute, now.second))
+
+    def time_z(self):
+        """Return now() in RFC3339 UTC Format."""
+        now = datetime.datetime.now()
+        return now.isoformat("T") + "Z"
 
     def _get_builtin_handler(self, log, key):
         for h in log.handlers:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -314,9 +314,9 @@ class LogManager(object):
         month = monthnames[now.month - 1].capitalize()
         return ('[%02d/%s/%04d:%02d:%02d:%02d]' %
                 (now.day, month, now.year, now.hour, now.minute, now.second))
-                
+
     @staticmethod
-    def time_z(self):
+    def time_z():
         """Return now() in RFC3339 UTC Format."""
         now = datetime.datetime.now()
         return now.isoformat('T') + 'Z'

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -262,7 +262,7 @@ class LogManager(object):
                  'f': dict.get(inheaders, 'Referer', ''),
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
-                 'i': request.uuid,
+                 'i': response.uuid,
                  'z': self.time_z(),
                  }
         if six.PY3:

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -251,6 +251,7 @@ class LogManager(object):
             status = response.output_status.split(ntob(' '), 1)[0]
             if six.PY3:
                 status = status.decode('ISO-8859-1')
+                
         atoms = {'h': remote.name or remote.ip,
                  'l': '-',
                  'u': getattr(request, 'login', None) or '-',

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -263,7 +263,7 @@ class LogManager(object):
                  'a': dict.get(inheaders, 'User-Agent', ''),
                  'o': dict.get(inheaders, 'Host', '-'),
                  'i': str(response.uuid),
-                 'z': self.time_z(),
+                 'z': LazyRfc3339UtcTime(),
                  }
         if six.PY3:
             for k, v in atoms.items():
@@ -313,12 +313,6 @@ class LogManager(object):
         month = monthnames[now.month - 1].capitalize()
         return ('[%02d/%s/%04d:%02d:%02d:%02d]' %
                 (now.day, month, now.year, now.hour, now.minute, now.second))
-
-    @staticmethod
-    def time_z():
-        """Return now() in RFC3339 UTC Format."""
-        now = datetime.datetime.now()
-        return now.isoformat('T') + 'Z'
 
     def _get_builtin_handler(self, log, key):
         for h in log.handlers:
@@ -470,3 +464,10 @@ class WSGIErrorHandler(logging.Handler):
                 self.flush()
             except:
                 self.handleError(record)
+
+
+class LazyRfc3339UtcTime(object):
+    def __str__(self):
+        """Return now() in RFC3339 UTC Format."""
+        now = datetime.datetime.now()
+        return now.isoformat('T') + 'Z'

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -951,6 +951,7 @@ class Response(object):
 
         # Transform our header dict into a list of tuples.
         self.header_list = h = headers.output()
+
         cookie = self.cookie.output()
         if cookie:
             for line in cookie.split('\r\n'):

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -902,7 +902,7 @@ class Response(object):
         self.header_list = None
         self._body = []
         self.time = time.time()
-        self._uuid = ""
+        self._uuid = ''
 
         self.headers = httputil.HeaderMap()
         # Since we know all our keys are titled strings, we can

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -975,7 +975,7 @@ class Response(object):
 class LazyUUID4(object):
     def __str__(self):
         """Return UUID4 and keep it for future calls."""
-        return self.uuid4
+        return str(self.uuid4)
 
     @property
     def uuid4(self):

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -902,7 +902,7 @@ class Response(object):
         self.header_list = None
         self._body = []
         self.time = time.time()
-        self._uuid = None
+        self._uuid = ""
 
         self.headers = httputil.HeaderMap()
         # Since we know all our keys are titled strings, we can
@@ -967,7 +967,7 @@ class Response(object):
 
         # Transform our header dict into a list of tuples.
         self.header_list = h = headers.output()
-
+        self.uuid = self.get_uuid()
         cookie = self.cookie.output()
         if cookie:
             for line in cookie.split('\r\n'):

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -4,7 +4,6 @@ import warnings
 
 import six
 from six.moves.http_cookies import SimpleCookie, CookieError
-import uuid
 
 import cherrypy
 from cherrypy._cpcompat import text_or_bytes, ntob
@@ -912,9 +911,6 @@ class Response(object):
         self.body = newbody
         return newbody
 
-    def __str__(self):
-        return uuid.uuid4()
-
     def finalize(self):
         """Transform headers (and cookies) into self.header_list. (Core)"""
         try:
@@ -927,7 +923,6 @@ class Response(object):
         self.status = '%s %s' % (code, reason)
         self.output_status = ntob(str(code), 'ascii') + \
             ntob(' ') + headers.encode(reason)
-        self.uuid = self.__str__()
 
         if self.stream:
             # The upshot: wsgiserver will chunk the response if

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -890,7 +890,6 @@ class Response(object):
         self.header_list = None
         self._body = []
         self.time = time.time()
-        self._uuid = ''
 
         self.headers = httputil.HeaderMap()
         # Since we know all our keys are titled strings, we can

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -2,6 +2,7 @@ import sys
 import time
 import warnings
 
+import uuid
 import six
 from six.moves.http_cookies import SimpleCookie, CookieError
 
@@ -834,6 +835,20 @@ class ResponseBody(object):
         obj._body = value
 
 
+class RequestUuid(object):
+
+    """The UUIDv4."""
+    def __get__(self, obj, objclass=None):
+        if obj is None:
+            # When calling on the class instead of instance...
+            return self
+        else:
+            return obj._uuid
+
+    def __set__(self, obj, value):
+        obj._uuid = uuid.uuid4()
+
+
 class Response(object):
 
     """An HTTP Response, including status, headers, and body."""
@@ -879,11 +894,15 @@ class Response(object):
     stream = False
     """If False, buffer the response body."""
 
+    uuid = RequestUuid()
+    """The uuidv4 (entity) of the HTTP request."""
+
     def __init__(self):
         self.status = None
         self.header_list = None
         self._body = []
         self.time = time.time()
+        self._uuid = None
 
         self.headers = httputil.HeaderMap()
         # Since we know all our keys are titled strings, we can
@@ -894,6 +913,9 @@ class Response(object):
             'Date': httputil.HTTPDate(self.time),
         })
         self.cookie = SimpleCookie()
+
+    def get_uuid(self):
+        return self.uuid
 
     def collapse_body(self):
         """Collapse self.body to a single string; replace it and return it."""

--- a/cherrypy/_cprequest.py
+++ b/cherrypy/_cprequest.py
@@ -4,6 +4,7 @@ import warnings
 
 import six
 from six.moves.http_cookies import SimpleCookie, CookieError
+import uuid
 
 import cherrypy
 from cherrypy._cpcompat import text_or_bytes, ntob
@@ -911,6 +912,9 @@ class Response(object):
         self.body = newbody
         return newbody
 
+    def __str__(self):
+        return uuid.uuid4()
+
     def finalize(self):
         """Transform headers (and cookies) into self.header_list. (Core)"""
         try:
@@ -923,6 +927,7 @@ class Response(object):
         self.status = '%s %s' % (code, reason)
         self.output_status = ntob(str(code), 'ascii') + \
             ntob(' ') + headers.encode(reason)
+        self.uuid = self.__str__()
 
         if self.stream:
             # The upshot: wsgiserver will chunk the response if

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -176,12 +176,15 @@ class LogCase(object):
                 uuid_log = data[-1]
                 uuid_obj = UUID(uuid_log, version=4)
             except (TypeError, ValueError):
-                msg = '%r not a valid UUIDv4' % uuid_log
-                self._handleLogError(msg, data, marker, log_chunk)
+                pass  # it might be in other chunk
             else:
-                if str(uuid_obj) != uuid_log:
-                    msg = '%r not a valid UUIDv4' % uuid_log
-                    self._handleLogError(msg, data, marker, log_chunk)
+                if str(uuid_obj) == uuid_log:
+                    return
+                msg = '%r is not a valid UUIDv4' % uuid_log
+                self._handleLogError(msg, data, marker, log_chunk)
+
+        msg = 'UUIDv4 not found in log'
+        self._handleLogError(msg, data, marker, log_chunk)
 
     def assertLog(self, sliceargs, lines, marker=None):
         """Fail if log.readlines()[sliceargs] is not contained in 'lines'.

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -173,7 +173,6 @@ class LogCase(object):
         msg = ''
         for lines in data:
             uuid_log = lines[:-1].decode('utf-8')
-            uuid_obj = UUID(uuid_log, version=4)
             try:
                 uuid_obj = UUID(uuid_log, version=4)
             except:

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -172,7 +172,7 @@ class LogCase(object):
         uuid_obj = ''
         msg = ''
         for lines in data:
-            uuid_log = lines[:-1].decode("utf-8")
+            uuid_log = lines[:-1].decode('utf-8')
             uuid_obj = UUID(uuid_log, version=4)
             try:
                 uuid_obj = UUID(uuid_log, version=4)
@@ -182,7 +182,6 @@ class LogCase(object):
                 if str(uuid_obj) != uuid_log:
                     msg = '%r not a valid UUIDv4' % uuid_log
                     self._handleLogError(msg, data, marker, lines)
-
 
     def assertLog(self, sliceargs, lines, marker=None):
         """Fail if log.readlines()[sliceargs] is not contained in 'lines'.

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -4,7 +4,7 @@ import sys
 import time
 
 import six
-
+from uuid import UUID
 from cherrypy._cpcompat import text_or_bytes, ntob
 
 
@@ -160,6 +160,29 @@ class LogCase(object):
             if line in logline:
                 msg = '%r found in log' % line
                 self._handleLogError(msg, data, marker, line)
+
+    def assertValidUUIDv4(self, marker=None):
+        """Fail if the given UUIDv4 is not valid.
+
+        The log will be searched from the given marker to the next marker.
+        If marker is None, self.lastmarker is used. If the log hasn't
+        been marked (using self.markLog), the entire log will be searched.
+        """
+        data = self._read_marked_region(marker)
+        uuid_obj = ''
+        msg = ''
+        for lines in data:
+            uuid_log = lines[:-1].decode("utf-8")
+            uuid_obj = UUID(uuid_log, version=4)
+            try:
+                uuid_obj = UUID(uuid_log, version=4)
+            except:
+                msg = '%r not a valid UUIDv4' % uuid_log
+            finally:
+                if str(uuid_obj) != uuid_log:
+                    msg = '%r not a valid UUIDv4' % uuid_log
+                    self._handleLogError(msg, data, marker, lines)
+
 
     def assertLog(self, sliceargs, lines, marker=None):
         """Fail if log.readlines()[sliceargs] is not contained in 'lines'.

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -176,11 +176,11 @@ class LogCase(object):
                 uuid_obj = UUID(uuid_log, version=4)
             except (TypeError, ValueError):
                 msg = '%r not a valid UUIDv4' % uuid_log
-                self._handleLogError(msg, data, marker, lines)
+                self._handleLogError(msg, data, marker, log_chunk)
             else:
                 if str(uuid_obj) != uuid_log:
                     msg = '%r not a valid UUIDv4' % uuid_log
-                    self._handleLogError(msg, data, marker, lines)
+                    self._handleLogError(msg, data, marker, log_chunk)
 
     def assertLog(self, sliceargs, lines, marker=None):
         """Fail if log.readlines()[sliceargs] is not contained in 'lines'.

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -4,7 +4,6 @@ import sys
 import time
 
 import six
-from uuid import UUID
 from cherrypy._cpcompat import text_or_bytes, ntob
 
 
@@ -160,27 +159,6 @@ class LogCase(object):
             if line in logline:
                 msg = '%r found in log' % line
                 self._handleLogError(msg, data, marker, line)
-
-    def assertValidUUIDv4(self, marker=None):
-        """Fail if the given UUIDv4 is not valid.
-
-        The log will be searched from the given marker to the next marker.
-        If marker is None, self.lastmarker is used. If the log hasn't
-        been marked (using self.markLog), the entire log will be searched.
-        """
-        data = self._read_marked_region(marker)
-        uuid_obj = ''
-        msg = ''
-        for lines in data:
-            uuid_log = lines[:-1].decode('utf-8')
-            try:
-                uuid_obj = UUID(uuid_log, version=4)
-            except:
-                msg = '%r not a valid UUIDv4' % uuid_log
-            finally:
-                if str(uuid_obj) != uuid_log:
-                    msg = '%r not a valid UUIDv4' % uuid_log
-                    self._handleLogError(msg, data, marker, lines)
 
     def assertLog(self, sliceargs, lines, marker=None):
         """Fail if log.readlines()[sliceargs] is not contained in 'lines'.

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -2,6 +2,7 @@
 
 import sys
 import time
+from uuid import UUID
 
 import six
 

--- a/cherrypy/test/logtest.py
+++ b/cherrypy/test/logtest.py
@@ -4,6 +4,7 @@ import sys
 import time
 
 import six
+
 from cherrypy._cpcompat import text_or_bytes, ntob
 
 
@@ -159,6 +160,27 @@ class LogCase(object):
             if line in logline:
                 msg = '%r found in log' % line
                 self._handleLogError(msg, data, marker, line)
+
+    def assertValidUUIDv4(self, marker=None):
+        """Fail if the given UUIDv4 is not valid.
+
+        The log will be searched from the given marker to the next marker.
+        If marker is None, self.lastmarker is used. If the log hasn't
+        been marked (using self.markLog), the entire log will be searched.
+        """
+        data = self._read_marked_region(marker)
+        data = [chunk.decode('utf-8').rstrip('\n').rstrip('\r') for chunk in data]
+        for log_chunk in data:
+            try:
+                uuid_log = data[-1]
+                uuid_obj = UUID(uuid_log, version=4)
+            except (TypeError, ValueError):
+                msg = '%r not a valid UUIDv4' % uuid_log
+                self._handleLogError(msg, data, marker, lines)
+            else:
+                if str(uuid_obj) != uuid_log:
+                    msg = '%r not a valid UUIDv4' % uuid_log
+                    self._handleLogError(msg, data, marker, lines)
 
     def assertLog(self, sliceargs, lines, marker=None):
         """Fail if log.readlines()[sliceargs] is not contained in 'lines'.

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -111,7 +111,7 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         'cherrypy._cplogging.LogManager.access_log_format',
         '{h} {l} {u} {t} "{r}" {s} {b} "{f}" "{a}" {o}'
         if six.PY3 else
-        '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
+        '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
     )
     def testCustomLogFormat(self):
         """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -127,6 +127,44 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
 
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
+    def testUUIDv4ParameterLogFormat(self):
+        '''Test a customized access_log_format string,
+           which is a feature of _cplogging.LogManager.access() '''
+
+        original_logformat = cherrypy._cplogging.LogManager.access_log_format
+        cherrypy._cplogging.LogManager.access_log_format = (
+            '{i}' if six.PY3
+            else
+            '%(i)s'
+        )
+
+        self.markLog()
+        self.getPage('/as_string')
+        self.assertValidUUIDv4()
+
+        cherrypy._cplogging.LogManager.access_log_format = original_logformat
+
+    def testTimezLogFormat(self):
+        '''Test a customized access_log_format string,
+           which is a feature of _cplogging.LogManager.access() '''
+
+        original_logformat = cherrypy._cplogging.LogManager.access_log_format
+        cherrypy._cplogging.LogManager.access_log_format = (
+            '{h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
+            else
+            '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
+        )
+
+        self.markLog()
+        self.getPage('/as_string', headers=[('Referer', 'REFERER'),
+                                            ('User-Agent', 'USERAGENT'),
+                                            ('Host', 'HOST')])
+        self.assertLog(-1, '%s - - ' % self.interface())
+        self.assertLog(-1, ' "GET /as_string HTTP/1.1" '
+                           '200 7 "REFERER" "USERAGENT" HOST')
+
+        cherrypy._cplogging.LogManager.access_log_format = original_logformat
+
     def testEscapedOutput(self):
         # Test unicode in access log pieces.
         self.markLog()

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -150,8 +150,7 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         '{i}' if six.PY3 else '%(i)s'
     )
     def testUUIDv4ParameterLogFormat(self):
-        '''Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() '''
+        """Test rendering of UUID4 within access log."""
         self.markLog()
         self.getPage('/as_string')
         self.assertValidUUIDv4()

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -127,44 +127,6 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
 
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
-    def testUUIDv4ParameterLogFormat(self):
-        '''Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() '''
-
-        original_logformat = cherrypy._cplogging.LogManager.access_log_format
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{i}' if six.PY3
-            else
-            '%(i)s'
-        )
-
-        self.markLog()
-        self.getPage('/as_string')
-        self.assertValidUUIDv4()
-
-        cherrypy._cplogging.LogManager.access_log_format = original_logformat
-
-    def testTimezLogFormat(self):
-        '''Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() '''
-
-        original_logformat = cherrypy._cplogging.LogManager.access_log_format
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
-            else
-            '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
-        )
-
-        self.markLog()
-        self.getPage('/as_string', headers=[('Referer', 'REFERER'),
-                                            ('User-Agent', 'USERAGENT'),
-                                            ('Host', 'HOST')])
-        self.assertLog(-1, '%s - - ' % self.interface())
-        self.assertLog(-1, ' "GET /as_string HTTP/1.1" '
-                           '200 7 "REFERER" "USERAGENT" HOST')
-
-        cherrypy._cplogging.LogManager.access_log_format = original_logformat
-
     def testEscapedOutput(self):
         # Test unicode in access log pieces.
         self.markLog()

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -132,10 +132,15 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
     def testTimezLogFormat(self):
         """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
         self.markLog()
-        self.getPage('/as_string', headers=[('Referer', 'REFERER'),
-                                            ('User-Agent', 'USERAGENT'),
-                                            ('Host', 'HOST')])
+
+        expected_time = str(cherrypy._cplogging.LazyRfc3339UtcTime())
+        with mock.patch('cherrypy._cplogging.LazyRfc3339UtcTime', lambda: expected_time):
+            self.getPage('/as_string', headers=[('Referer', 'REFERER'),
+                                                ('User-Agent', 'USERAGENT'),
+                                                ('Host', 'HOST')])
+
         self.assertLog(-1, '%s - - ' % self.interface())
+        self.assertLog(-1, expected_time)
         self.assertLog(-1, ' "GET /as_string HTTP/1.1" '
                            '200 7 "REFERER" "USERAGENT" HOST')
 

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -107,15 +107,14 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
             self.assertLog(-1, '] "GET %s/as_yield HTTP/1.1" 200 - "" ""'
                            % self.prefix())
 
+    @mock.patch(
+        'cherrypy._cplogging.LogManager.access_log_format',
+        '{h} {l} {u} {t} "{r}" {s} {b} "{f}" "{a}" {o}'
+        if six.PY3 else
+        '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
+    )
     def testCustomLogFormat(self):
         """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
-        original_logformat = cherrypy._cplogging.LogManager.access_log_format
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{h} {l} {u} {t} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
-            else
-            '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
-        )
-
         self.markLog()
         self.getPage('/as_string', headers=[('Referer', 'REFERER'),
                                             ('User-Agent', 'USERAGENT'),
@@ -124,17 +123,14 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         self.assertLog(-1, '] "GET /as_string HTTP/1.1" '
                            '200 7 "REFERER" "USERAGENT" HOST')
 
-        cherrypy._cplogging.LogManager.access_log_format = original_logformat
-
+    @mock.patch(
+        'cherrypy._cplogging.LogManager.access_log_format',
+        '{h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}'
+        if six.PY3 else
+        '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
+    )
     def testTimezLogFormat(self):
         """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
-        original_logformat = cherrypy._cplogging.LogManager.access_log_format
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
-            else
-            '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
-        )
-
         self.markLog()
         self.getPage('/as_string', headers=[('Referer', 'REFERER'),
                                             ('User-Agent', 'USERAGENT'),
@@ -142,8 +138,6 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         self.assertLog(-1, '%s - - ' % self.interface())
         self.assertLog(-1, ' "GET /as_string HTTP/1.1" '
                            '200 7 "REFERER" "USERAGENT" HOST')
-
-        cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
     @mock.patch(
         'cherrypy._cplogging.LogManager.access_log_format',

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -154,11 +154,6 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
             else
             '%(i)s'
         )
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{i} {h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
-            else
-            '%(i)s %(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
-        )
 
         self.markLog()
         self.getPage('/as_string')

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -125,21 +125,6 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
 
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
-    def testUUIDv4ParameterLogFormat(self):
-        """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
-        original_logformat = cherrypy._cplogging.LogManager.access_log_format
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{i}' if six.PY3
-            else
-            '%(i)s'
-        )
-
-        self.markLog()
-        self.getPage('/as_string')
-        self.assertValidUUIDv4()
-
-        cherrypy._cplogging.LogManager.access_log_format = original_logformat
-
     def testTimezLogFormat(self):
         """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
         original_logformat = cherrypy._cplogging.LogManager.access_log_format
@@ -169,31 +154,15 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
             else
             '%(i)s'
         )
+        cherrypy._cplogging.LogManager.access_log_format = (
+            '{i} {h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
+            else
+            '%(i)s %(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
+        )
 
         self.markLog()
         self.getPage('/as_string')
         self.assertValidUUIDv4()
-
-        cherrypy._cplogging.LogManager.access_log_format = original_logformat
-
-    def testTimezLogFormat(self):
-        '''Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() '''
-
-        original_logformat = cherrypy._cplogging.LogManager.access_log_format
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
-            else
-            '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
-        )
-
-        self.markLog()
-        self.getPage('/as_string', headers=[('Referer', 'REFERER'),
-                                            ('User-Agent', 'USERAGENT'),
-                                            ('Host', 'HOST')])
-        self.assertLog(-1, '%s - - ' % self.interface())
-        self.assertLog(-1, ' "GET /as_string HTTP/1.1" '
-                           '200 7 "REFERER" "USERAGENT" HOST')
 
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -107,9 +107,7 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
                            % self.prefix())
 
     def testCustomLogFormat(self):
-        """Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() """
-
+        """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
         original_logformat = cherrypy._cplogging.LogManager.access_log_format
         cherrypy._cplogging.LogManager.access_log_format = (
             '{h} {l} {u} {t} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
@@ -128,9 +126,7 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
     def testUUIDv4ParameterLogFormat(self):
-        """Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() """
-
+        """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
         original_logformat = cherrypy._cplogging.LogManager.access_log_format
         cherrypy._cplogging.LogManager.access_log_format = (
             '{i}' if six.PY3
@@ -145,9 +141,7 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
     def testTimezLogFormat(self):
-        """Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() """
-
+        """Test a customized access_log_format string, which is a feature of _cplogging.LogManager.access()."""
         original_logformat = cherrypy._cplogging.LogManager.access_log_format
         cherrypy._cplogging.LogManager.access_log_format = (
             '{h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -165,6 +165,44 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
 
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
+    def testUUIDv4ParameterLogFormat(self):
+        '''Test a customized access_log_format string,
+           which is a feature of _cplogging.LogManager.access() '''
+
+        original_logformat = cherrypy._cplogging.LogManager.access_log_format
+        cherrypy._cplogging.LogManager.access_log_format = (
+            '{i}' if six.PY3
+            else
+            '%(i)s'
+        )
+
+        self.markLog()
+        self.getPage('/as_string')
+        self.assertValidUUIDv4()
+
+        cherrypy._cplogging.LogManager.access_log_format = original_logformat
+
+    def testTimezLogFormat(self):
+        '''Test a customized access_log_format string,
+           which is a feature of _cplogging.LogManager.access() '''
+
+        original_logformat = cherrypy._cplogging.LogManager.access_log_format
+        cherrypy._cplogging.LogManager.access_log_format = (
+            '{h} {l} {u} {z} "{r}" {s} {b} "{f}" "{a}" {o}' if six.PY3
+            else
+            '%(h)s %(l)s %(u)s %(z)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(o)s'
+        )
+
+        self.markLog()
+        self.getPage('/as_string', headers=[('Referer', 'REFERER'),
+                                            ('User-Agent', 'USERAGENT'),
+                                            ('Host', 'HOST')])
+        self.assertLog(-1, '%s - - ' % self.interface())
+        self.assertLog(-1, ' "GET /as_string HTTP/1.1" '
+                           '200 7 "REFERER" "USERAGENT" HOST')
+
+        cherrypy._cplogging.LogManager.access_log_format = original_logformat
+
     def testEscapedOutput(self):
         # Test unicode in access log pieces.
         self.markLog()

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -107,8 +107,8 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
                            % self.prefix())
 
     def testCustomLogFormat(self):
-        '''Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() '''
+        """Test a customized access_log_format string,
+           which is a feature of _cplogging.LogManager.access() """
 
         original_logformat = cherrypy._cplogging.LogManager.access_log_format
         cherrypy._cplogging.LogManager.access_log_format = (
@@ -128,8 +128,8 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
     def testUUIDv4ParameterLogFormat(self):
-        '''Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() '''
+        """Test a customized access_log_format string,
+           which is a feature of _cplogging.LogManager.access() """
 
         original_logformat = cherrypy._cplogging.LogManager.access_log_format
         cherrypy._cplogging.LogManager.access_log_format = (
@@ -145,8 +145,8 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
     def testTimezLogFormat(self):
-        '''Test a customized access_log_format string,
-           which is a feature of _cplogging.LogManager.access() '''
+        """Test a customized access_log_format string,
+           which is a feature of _cplogging.LogManager.access() """
 
         original_logformat = cherrypy._cplogging.LogManager.access_log_format
         cherrypy._cplogging.LogManager.access_log_format = (

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -1,6 +1,7 @@
 """Basic tests for the CherryPy core: request handling."""
 
 import os
+from unittest import mock
 
 import six
 
@@ -144,22 +145,16 @@ class AccessLogTests(helper.CPWebCase, logtest.LogCase):
 
         cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
+    @mock.patch(
+        'cherrypy._cplogging.LogManager.access_log_format',
+        '{i}' if six.PY3 else '%(i)s'
+    )
     def testUUIDv4ParameterLogFormat(self):
         '''Test a customized access_log_format string,
            which is a feature of _cplogging.LogManager.access() '''
-
-        original_logformat = cherrypy._cplogging.LogManager.access_log_format
-        cherrypy._cplogging.LogManager.access_log_format = (
-            '{i}' if six.PY3
-            else
-            '%(i)s'
-        )
-
         self.markLog()
         self.getPage('/as_string')
         self.assertValidUUIDv4()
-
-        cherrypy._cplogging.LogManager.access_log_format = original_logformat
 
     def testEscapedOutput(self):
         # Test unicode in access log pieces.

--- a/cherrypy/test/test_request_obj.py
+++ b/cherrypy/test/test_request_obj.py
@@ -4,6 +4,7 @@ from functools import wraps
 import os
 import sys
 import types
+import uuid
 
 import six
 from six.moves.http_client import IncompleteRead
@@ -45,6 +46,14 @@ class RequestObjectTests(helper.CPWebCase):
             def body_example_com_3128(self):
                 """Handle CONNECT method."""
                 return cherrypy.request.method + 'ed to ' + cherrypy.request.path_info
+
+            @cherrypy.expose
+            def request_uuid4(self):
+                return [
+                    str(cherrypy.request.unique_id),
+                    ' ',
+                    str(cherrypy.request.unique_id),
+                ]
 
         root = Root()
 
@@ -310,6 +319,15 @@ class RequestObjectTests(helper.CPWebCase):
     def test_scheme(self):
         self.getPage('/scheme')
         self.assertBody(self.scheme)
+
+    def test_per_request_uuid4(self):
+        self.getPage('/request_uuid4')
+        first_uuid4, _, second_uuid4 = self.body.decode().partition(' ')
+        assert uuid.UUID(first_uuid4, version=4) == uuid.UUID(second_uuid4, version=4)
+
+        self.getPage('/request_uuid4')
+        third_uuid4, _, _ = self.body.decode().partition(' ')
+        assert uuid.UUID(first_uuid4, version=4) != uuid.UUID(third_uuid4, version=4)
 
     def testRelativeURIPathInfo(self):
         self.getPage('/pathinfo/foo/bar')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the related issue number (starting with `#`)**



* **What is the current behavior?** (You can also link to an open issue here)
There isn't the possibility to configure acces_log_format with uuidv4 and timestamp in rfc3339 format


* **What is the new behavior (if this is a feature change)?**
You can use "%(i)s" to have a unique request_id in the log
You can use "%(z)s" to have a UTC rfc3339 timestamp in the log


* **Other information**:
first PR ever, if something is wrong please don't be mean :dagger: 