### PR TITLE
Use single subscribe method for decorator or direct invocation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,9 @@
 v11.2.0
 -------
 
-* Added ``cherrypy.engine.subscribed``, providing syntactic sugar
-  for decorating a callback for ``cherrypy.engine.subscribe``.
+* ``cherrypy.engine.subscribe`` now may be called without a
+  callback, in which case it returns a decorator expecting the
+  callback.
 
 v11.1.0
 -------

--- a/cherrypy/__init__.py
+++ b/cherrypy/__init__.py
@@ -367,7 +367,7 @@ log.error_file = ''
 log.access_file = ''
 
 
-@engine.subscribed('log')
+@engine.subscribe('log')
 def _buslog(msg, level):
     log.error(msg, 'ENGINE', severity=level)
 

--- a/cherrypy/_cpmodpy.py
+++ b/cherrypy/_cpmodpy.py
@@ -102,7 +102,7 @@ def setup(req):
     engine.autoreload.unsubscribe()
     cherrypy.server.unsubscribe()
 
-    @engine.subscribed('log')
+    @engine.subscribe('log')
     def _log(msg, level):
         newlevel = apache.APLOG_ERR
         if logging.DEBUG >= level:

--- a/cherrypy/process/wspbus.py
+++ b/cherrypy/process/wspbus.py
@@ -192,7 +192,7 @@ class Bus(object):
         if callback is None:
             return functools.partial(
                 self.subscribe,
-                channel=channel,
+                channel,
                 priority=priority,
             )
 

--- a/cherrypy/process/wspbus.py
+++ b/cherrypy/process/wspbus.py
@@ -183,18 +183,25 @@ class Bus(object):
         )
         self._priorities = {}
 
-    def subscribe(self, channel, callback, priority=None):
-        """Add the given callback at the given channel (if not present)."""
+    def subscribe(self, channel, callback=None, priority=None):
+        """Add the given callback at the given channel (if not present).
+
+        If callback is None, return a partial suitable for decorating
+        the callback.
+        """
+        if callback is None:
+            return functools.partial(
+                self.subscribe,
+                channel=channel,
+                priority=priority,
+            )
+
         ch_listeners = self.listeners.setdefault(channel, set())
         ch_listeners.add(callback)
 
         if priority is None:
             priority = getattr(callback, 'priority', 50)
         self._priorities[(channel, callback)] = priority
-
-    def subscribed(self, *args, **kwargs):
-        """Decorator factory for self.subscribe"""
-        return functools.partial(self.subscribe, *args, **kwargs)
 
     def unsubscribe(self, channel, callback):
         """Discard the given callback (if present)."""

--- a/cherrypy/test/_test_states_demo.py
+++ b/cherrypy/test/_test_states_demo.py
@@ -35,7 +35,7 @@ class Root:
         cherrypy.engine.exit()
 
 
-@cherrypy.engine.subscribed('start', priority=100)
+@cherrypy.engine.subscribe('start', priority=100)
 def unsub_sig():
     cherrypy.log('unsubsig: %s' % cherrypy.config.get('unsubsig', False))
     if cherrypy.config.get('unsubsig', False):
@@ -53,13 +53,13 @@ def unsub_sig():
         signal(SIGTERM, old_term_handler)
 
 
-@cherrypy.engine.subscribed('start', priority=6)
+@cherrypy.engine.subscribe('start', priority=6)
 def starterror():
     if cherrypy.config.get('starterror', False):
         1 / 0
 
 
-@cherrypy.engine.subscribed('start', priority=6)
+@cherrypy.engine.subscribe('start', priority=6)
 def log_test_case_name():
     if cherrypy.config.get('test_case_name', False):
         cherrypy.log('STARTED FROM: %s' %


### PR DESCRIPTION
This approach presents an alternative approach to afb5b33fe3, in which only one subscribe method is presented and the decorator functionality is exposed when no callback is supplied.

Thoughts?