### PR TITLE
Drop support for Python 3.2 and 3.1.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 v12.0.0
 -------
 
+* Drop support for Python 3.1 and 3.2.
+
 * #1625: Removed response timeout and timeout monitor and
   related exceptions, as it not possible to interrupt a request.
   Servers that wish to exit a request prematurely are

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ classifiers = [
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.1',
-    'Programming Language :: Python :: 3.2',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
@@ -118,7 +116,7 @@ setup_params = dict(
     setup_requires=[
         'setuptools_scm',
     ],
-    python_requires='>=2.7,!=3.0.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
 )
 
 


### PR DESCRIPTION
As our CI runners no longer support Python 3.2, and as there exists CherryPy 11 for those platforms, let's limit our scope of support and drop support for Python 3.2.