### PR TITLE
Remove 'max-age' when expiring cookies

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -906,3 +906,4 @@ def expire():
     one_year = 60 * 60 * 24 * 365
     e = time.time() - one_year
     cherrypy.serving.response.cookie[name]['expires'] = httputil.HTTPDate(e)
+    cherrypy.serving.response.cookie[name].pop('max-age', None)


### PR DESCRIPTION
According to [RFC 6256]:
> If a cookie has both the Max-Age and the Expires attribute, the
> Max-Age attribute has precedence and controls the expiration date of
> the cookie.

Therefore, when attempting to expire the current session cookie by
setting the `expires` property to a value in the past, the `max-age`
needs to be removed so that it doesn't override the new `expires` value.

This is a bug fix. Currently, calling `cherrypy.lib.sessions.expire()` doesn't properly expire cookies if they have a `max-age` property set on them.

  [RFC 6256]: https://tools.ietf.org/html/rfc6265#section-4.1.2.2