### PR TITLE
Internalize jaraco.classes code to replace dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v13.0.1
+-------
+
+* #1671: Restore support for installing CherryPy into
+  environments hostile to namespace packages, broken since
+  the 11.1.0 release.
+
 v13.0.0
 -------
 
@@ -100,6 +107,10 @@ v11.1.0
 
 * Also, many improvements around continuous integration and code
   quality checks.
+
+This release contained an unintentional regression in environments that
+are hostile to namespace packages, such as Pex, Celery, and py2exe.
+See #1671 for details.
 
 v11.0.0
 -------

--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -125,12 +125,11 @@ from xml.sax import saxutils
 import six
 from six.moves import urllib
 
-from jaraco.classes.properties import classproperty
-
 import cherrypy
 from cherrypy._cpcompat import escape_html
 from cherrypy._cpcompat import text_or_bytes, ntob
 from cherrypy._cpcompat import tonative
+from cherrypy._helper import classproperty
 from cherrypy.lib import httputil as _httputil
 
 

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -310,11 +310,9 @@ def normalize_path(path):
     return newpath
 
 
-# Internalized from jaraco.classes because the dependency was a namespaced
-# package which is regretfully still unsupported in some cases of Python
-# environments (Pex, Celery, pip install -t)
-#
-# Code from http://stackoverflow.com/a/5191224
+####
+# Inlined from jaraco.classes 1.4.3
+# Ref #1673
 class _ClassPropertyDescriptor(object):
     """Descript for read-only class-based property.
 
@@ -334,10 +332,10 @@ class _ClassPropertyDescriptor(object):
         return self.fget.__get__(obj, klass)()
 
 
-# Code from http://stackoverflow.com/a/5191224
 def classproperty(func):
     """Decorator like classmethod to implement a static class property."""
     if not isinstance(func, (classmethod, staticmethod)):
         func = classmethod(func)
 
     return _ClassPropertyDescriptor(func)
+####

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -308,3 +308,36 @@ def normalize_path(path):
         newpath = '/' + newpath
 
     return newpath
+
+
+# Internalized from jaraco.classes because the dependency was a namespaced
+# package which is regretfully still unsupported in some cases of Python
+# environments (Pex, Celery, pip install -t)
+#
+# Code from http://stackoverflow.com/a/5191224
+class _ClassPropertyDescriptor(object):
+    """Descript for read-only class-based property.
+
+    Turns a classmethod-decorated func into a read-only property of that class
+    type (means the value cannot be set).
+    """
+
+    def __init__(self, fget, fset=None):
+        """Instantiated by ``_helper.classproperty``."""
+        self.fget = fget
+        self.fset = fset
+
+    def __get__(self, obj, klass=None):
+        """Return property value."""
+        if klass is None:
+            klass = type(obj)
+        return self.fget.__get__(obj, klass)()
+
+
+# Code from http://stackoverflow.com/a/5191224
+def classproperty(func):
+    """Decorator like classmethod to implement a static class property."""
+    if not isinstance(func, (classmethod, staticmethod)):
+        func = classmethod(func)
+
+    return _ClassPropertyDescriptor(func)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ install_requires = [
     'six>=1.11.0',
     'cheroot>=5.9.1',
     'portend>=2.1.1',
-    'jaraco.classes',
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ packages = [
     'cherrypy.scaffold',
 ]
 
+# install requirements must not contain namespace
+# packages. See #1673
 install_requires = [
     'six>=1.11.0',
     'cheroot>=5.9.1',


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

Resolves **a bug** when environment doesn't support namespaced packages

* **What is the related issue number (starting with `#`)**

https://github.com/jaraco/jaraco.classes/issues/2
https://github.com/jaraco/jaraco.classes/issues/3

* **What is the current behavior?** (You can also link to an open issue here)

Will happen in an environment that doesn't understand namespaced packages. For instance just do:

```
$ mkdir test
$ cd test
$ pip install cherrypy -t .
$ ls
ls
cheroot                  CherryPy-13.0.0.dist-info       jaraco.classes-1.4.3-py3.6-nspkg.pth  portend-2.2.dist-info  pytz                   six.py   tempora-1.10.dist-info
cheroot-6.0.0.dist-info  jaraco                          more_itertools                        portend.py             pytz-2017.3.dist-info  six.pyc
cherrypy                 jaraco.classes-1.4.3.dist-info  more_itertools-4.0.1.dist-info        portend.pyc            six-1.11.0.dist-info   tempora
$ python
Python 2.7.12 (default, Nov 20 2017, 18:23:56) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cherrypy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cherrypy/__init__.py", line 66, in <module>
    from ._cperror import (
  File "cherrypy/_cperror.py", line 128, in <module>
    from jaraco.classes.properties import classproperty
ImportError: No module named jaraco.classes.properties
>>> 
```

* **What is the new behavior (if this is a feature change)?**

The above will not happen. CherryPy will be more portable.

* **Other information**:

AFAIK this is a problem with Pex and Celery.