### PR TITLE
Factor classproperty out (referring to #1671)

### DIFF
--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -125,12 +125,11 @@ from xml.sax import saxutils
 import six
 from six.moves import urllib
 
-from jaraco.classes.properties import classproperty
-
 import cherrypy
 from cherrypy._cpcompat import escape_html
 from cherrypy._cpcompat import text_or_bytes, ntob
 from cherrypy._cpcompat import tonative
+from cherrypy._helper import classproperty
 from cherrypy.lib import httputil as _httputil
 
 

--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -129,7 +129,6 @@ import cherrypy
 from cherrypy._cpcompat import escape_html
 from cherrypy._cpcompat import text_or_bytes, ntob
 from cherrypy._cpcompat import tonative
-from cherrypy._helper import classproperty
 from cherrypy.lib import httputil as _httputil
 
 
@@ -229,16 +228,12 @@ class HTTPRedirect(CherryPyException):
 
         CherryPyException.__init__(self, abs_urls, status)
 
-    @classproperty
-    def default_status(cls):
-        """
-        The default redirect status for the request.
-
-        RFC 2616 indicates a 301 response code fits our goal; however,
-        browser support for 301 is quite messy. Use 302/303 instead. See
-        http://www.alanflavell.org.uk/www/post-redirect.html
-        """
-        return 303 if cherrypy.serving.request.protocol >= (1, 1) else 302
+    #: The default redirect status for the request.
+    #:
+    #: RFC 2616 indicates a 301 response code fits our goal; however,
+    #: browser support for 301 is quite messy. Use 302/303 instead. See
+    #: http://www.alanflavell.org.uk/www/post-redirect.html
+    default_status = _httputil.default_request_status()
 
     @property
     def status(self):

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -308,36 +308,3 @@ def normalize_path(path):
         newpath = '/' + newpath
 
     return newpath
-
-
-# Internalized from jaraco.classes because the dependency was a namespaced
-# package which is regretfully still unsupported in some cases of Python
-# environments (Pex, Celery, pip install -t)
-#
-# Code from http://stackoverflow.com/a/5191224
-class _ClassPropertyDescriptor(object):
-    """Descript for read-only class-based property.
-
-    Turns a classmethod-decorated func into a read-only property of that class
-    type (means the value cannot be set).
-    """
-
-    def __init__(self, fget, fset=None):
-        """Instantiated by ``_helper.classproperty``."""
-        self.fget = fget
-        self.fset = fset
-
-    def __get__(self, obj, klass=None):
-        """Return property value."""
-        if klass is None:
-            klass = type(obj)
-        return self.fget.__get__(obj, klass)()
-
-
-# Code from http://stackoverflow.com/a/5191224
-def classproperty(func):
-    """Decorator like classmethod to implement a static class property."""
-    if not isinstance(func, (classmethod, staticmethod)):
-        func = classmethod(func)
-
-    return _ClassPropertyDescriptor(func)

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -308,3 +308,36 @@ def normalize_path(path):
         newpath = '/' + newpath
 
     return newpath
+
+
+# Internalized from jaraco.classes because the dependency was a namespaced
+# package which is regretfully still unsupported in some cases of Python
+# environments (Pex, Celery, pip install -t)
+#
+# Code from http://stackoverflow.com/a/5191224
+class _ClassPropertyDescriptor(object):
+    """Descript for read-only class-based property.
+
+    Turns a classmethod-decorated func into a read-only property of that class
+    type (means the value cannot be set).
+    """
+
+    def __init__(self, fget, fset=None):
+        """Instantiated by ``_helper.classproperty``."""
+        self.fget = fget
+        self.fset = fset
+
+    def __get__(self, obj, klass=None):
+        """Return property value."""
+        if klass is None:
+            klass = type(obj)
+        return self.fget.__get__(obj, klass)()
+
+
+# Code from http://stackoverflow.com/a/5191224
+def classproperty(func):
+    """Decorator like classmethod to implement a static class property."""
+    if not isinstance(func, (classmethod, staticmethod)):
+        func = classmethod(func)
+
+    return _ClassPropertyDescriptor(func)

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -18,6 +18,7 @@ import six
 from six.moves import range, builtins
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler
 
+import cherrypy
 from cherrypy._cpcompat import ntob, ntou
 from cherrypy._cpcompat import text_or_bytes
 from cherrypy._cpcompat import unquote_qs
@@ -305,6 +306,17 @@ def valid_status(status):
         reason = default_reason
 
     return code, reason, message
+
+
+def default_request_status():
+    """
+    The default redirect status for a request.
+
+    RFC 2616 indicates a 301 response code fits our goal; however,
+    browser support for 301 is quite messy. Use 302/303 instead. See
+    http://www.alanflavell.org.uk/www/post-redirect.html
+    """
+    return 303 if cherrypy.serving.request.protocol >= (1, 1) else 302
 
 
 # NOTE: the parse_qs functions that follow are modified version of those

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ install_requires = [
     'six>=1.11.0',
     'cheroot>=5.9.1',
     'portend>=2.1.1',
-    'jaraco.classes',
 ]
 
 extras_require = {


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

This is a variant of #1671, perhaps less complicated because it removes the use of `classproperty`. I'd be in favor of this because: 1 less dependency, less code, less engineered