### PR TITLE
Add VS Code editor and virtualenv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,14 @@ sphinx/source/_build
 # Py.test
 /.cache/
 
-# Eclipse, PyDev
+# Eclipse, PyDev, VS Code
 .project
 .pydevproject
+.vscode
+
+# virtualenv
+VENV
+venv
 
 # test results in junit format for Appveyor
 /junit-test-results.xml


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Dev-ops Update

Modifies .gitignore in project repo to ignore configuration files for:

   Visual Studio Code Editor: https://code.visualstudio.com/
   Virtualenv: https://pypi.python.org/pypi/virtualenv

* **What is the related issue number (starting with `#`)**

N/A

* **What is the current behavior?** (You can also link to an open issue here)

These configuration files are present in calls to `git status` and `git add . --all`

* **What is the new behavior (if this is a feature change)?**

These files are ignored by `git status` and `git add . --all`

* **Other information**:

N/A