### PR TITLE
Convert params tool compatible with json_out

### DIFF
--- a/cherrypy/_cptools.py
+++ b/cherrypy/_cptools.py
@@ -537,6 +537,6 @@ _d.json_in = Tool('before_request_body', jsontools.json_in, priority=30)
 _d.json_out = Tool('before_handler', jsontools.json_out, priority=30)
 _d.auth_basic = Tool('before_handler', auth_basic.basic_auth, priority=1)
 _d.auth_digest = Tool('before_handler', auth_digest.digest_auth, priority=1)
-_d.params = Tool('before_handler', cptools.convert_params)
+_d.params = Tool('before_handler', cptools.convert_params, priority=15)
 
 del _d, cptools, encoding, auth, static

--- a/cherrypy/test/test_params.py
+++ b/cherrypy/test/test_params.py
@@ -10,6 +10,7 @@ class ParamsTest(helper.CPWebCase):
     def setup_server():
         class Root:
             @cherrypy.expose
+            @cherrypy.tools.json_out()
             @cherrypy.tools.params()
             def resource(self, limit=None, sort=None):
                 return type(limit).__name__
@@ -21,11 +22,11 @@ class ParamsTest(helper.CPWebCase):
     def test_pass(self):
         self.getPage('/resource')
         self.assertStatus(200)
-        self.assertBody('NoneType')
+        self.assertBody('"NoneType"')
 
         self.getPage('/resource?limit=0')
         self.assertStatus(200)
-        self.assertBody('int')
+        self.assertBody('"int"')
 
     def test_error(self):
         self.getPage('/resource?limit=')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the related issue number (starting with `#`)**



* **What is the current behavior?** (You can also link to an open issue here)
The `json_out` tool wraps the handler, breaking the `params` tool's introspection of the handler callable.


* **What is the new behavior (if this is a feature change)?**
`params` tools is prioritized before `json_out`.


* **Other information**: