### PR TITLE
Remove invalid link to StackOverflow Wiki.

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -18,10 +18,6 @@ tagged with 'cherrypy'. Answer unanswered questions, add an improved
 answer, clarify an answer with a comment, or ask more meaningful
 questions there. Earn reputation and share experience.
 
-CherryPy also maintains a `StackOverflow Wiki
-<http://stackoverflow.com/documentation/cherrypy/topics>`_ where
-anyone can publish tricks and techniques and refine others.
-
 Filing Bug Reports
 ==================
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs updates.


* **What is the related issue number (starting with `#`)**
n/A


* **What is the current behavior?** (You can also link to an open issue here)
Documentation links to an expired documentation service on StackOverflow.

From StackOverflow:

"We have shut down
Stack Overflow Documentation.
Documentation was our attempt at improving existing reference materials by focusing on examples. The beta ran from July 21st, 2016 until August 8th, 2017. For more details on why we ended it, please see our post on meta. Thank you to everyone that participated. As always, the content contributed by our community is available under CC-BY-SA: download the archive."


* **What is the new behavior (if this is a feature change)?**
N/A


* **Other information**:
