### PR TITLE
Fix for concurrent file session access

### DIFF
--- a/cherrypy/lib/lockfile.py
+++ b/cherrypy/lib/lockfile.py
@@ -77,8 +77,11 @@ class SystemLockFile(object):
         try:
             self._lock_file()
         except Exception:
-            self.fp.seek(1)
-            self.fp.close()
+            try:
+                self.fp.seek(1)
+                self.fp.close()
+            except IOError:
+                pass
             del self.fp
             raise
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
BugFix


* **What is the related issue number (starting with `#`)**
fixes #1193

* **What is the current behavior?** (You can also link to an open issue here)
First you need two cherrypy processes (Tom and Jerry) with sessions stored on shared filesystem. Application has two exposed handlers: `ShortAction` and `LongAction`.

Here is an description what happens:

1. Tom started to service `ShortAction` and it aquires lock on session.
2. Jerry started to service `LongAction` and tries to aquire lock on session.
3. `fcntl.flock(self.fp.fileno(), flags)` fails for Jerry and `UnixLockFile` raises `LockError`
4. Jerry catches it in line 79 and tries to seek and close `fp` in line 82.
5. Tom in meanwhile finished servicing `ShortAction` and deleted lock file.
6. Jerry calls `self.fp.close` and `FileNotFoundError` is raised.

* **What is the new behavior (if this is a feature change)?**
I catch `FileNotFoundError` and throw `LockError` instead. Jerry then tries to aquire lock on session again.

* **Other information**:
Tested and debugged on Python 3.6, Cherrypy 14.1, Linux.