### PR TITLE
cpstats: make 'Response Status' serializable

### DIFF
--- a/cherrypy/lib/cpstats.py
+++ b/cherrypy/lib/cpstats.py
@@ -196,7 +196,7 @@ import time
 import six
 
 import cherrypy
-from cherrypy._cpcompat import json
+from cherrypy._cpcompat import json, tonative
 
 # ------------------------------- Statistics -------------------------------- #
 
@@ -308,6 +308,14 @@ def _get_threading_ident():
     return threading._get_ident()
 
 
+def _get_response_status(resp):
+    try:
+        response_status = resp.output_status
+    except AttributeError:
+        response_status = resp.status
+    return tonative(response_status, 'utf-8')
+
+
 class StatsTool(cherrypy.Tool):
 
     """Record various information about the current request."""
@@ -366,8 +374,7 @@ class StatsTool(cherrypy.Tool):
             w['Bytes Written'] = cl
             appstats['Total Bytes Written'] += cl
 
-        w['Response Status'] = getattr(
-            resp, 'output_status', None) or resp.status
+        w['Response Status'] = _get_response_status(resp)
 
         w['End Time'] = time.time()
         p = w['End Time'] - w['Start Time']


### PR DESCRIPTION
Fixes an issue where it wasn't possible to fetch /cpstats/data when
running the cpstats tool with Python3.

Could potentially also solve the problem by supplying a default
function for 'json.dumps', but this solution seems cleaner.
