### PR TITLE
Fix URI decoding for auth_digest

### DIFF
--- a/cherrypy/lib/auth_digest.py
+++ b/cherrypy/lib/auth_digest.py
@@ -191,7 +191,7 @@ class HttpDigestAuthorization(object):
         items = parse_http_list(params)
         paramsd = parse_keqv_list(items)
         paramsd = {
-            k: unquote_to_bytes(v)
+            k: unquote_to_bytes(v) if k != "uri" else v
             for k, v in paramsd.items()
         }
         paramsd = _try_decode_map_values(paramsd, accept_charset)

--- a/cherrypy/test/test_auth_digest.py
+++ b/cherrypy/test/test_auth_digest.py
@@ -13,7 +13,7 @@ from cherrypy.test import helper
 
 
 def _fetch_users():
-    return {'test': 'test', 'йюзер': 'їпароль'}
+    return {'test': 'test', '☃йюзер': 'їпароль'}
 
 
 get_ha1 = cherrypy.lib.auth_digest.get_ha1_dict_plain(_fetch_users())
@@ -120,10 +120,10 @@ class DigestAuthTest(helper.CPWebCase):
         assert self.body == b"Hello test, you've been authorized."
 
     def test_unicode_user(self):
-        self._test_parametric_digest(username='йюзер', realm='localhost')
+        self._test_parametric_digest(username='☃йюзер', realm='localhost')
         assert self.status == '200 OK'
         assert self.body == ntob(
-            "Hello йюзер, you've been authorized.", 'utf-8',
+            "Hello ☃йюзер, you've been authorized.", 'utf-8',
         )
 
     def test_wrong_scheme(self):

--- a/cherrypy/test/test_auth_digest.py
+++ b/cherrypy/test/test_auth_digest.py
@@ -2,14 +2,14 @@
 # -*- coding: utf-8 -*-
 # vim:ts=4:sw=4:expandtab:fileencoding=utf-8
 
+import six
+
 
 import cherrypy
 from cherrypy.lib import auth_digest
 from cherrypy._cpcompat import ntob
 
 from cherrypy.test import helper
-
-from six.moves.urllib.parse import quote as urlencode
 
 
 def _fetch_users():
@@ -32,7 +32,7 @@ class DigestAuthTest(helper.CPWebCase):
         class DigestProtected:
 
             @cherrypy.expose
-            def index(self):
+            def index(self, *args, **kwargs):
                 return "Hello %s, you've been authorized." % (
                     cherrypy.request.login)
 
@@ -54,7 +54,9 @@ class DigestAuthTest(helper.CPWebCase):
         assert self.body == b'This is public.'
 
     def _test_parametric_digest(self, username, realm):
-        self.getPage('/digest/')
+        test_uri = '/digest/?@/=%2F%40&%f0%9f%99%88=path'
+
+        self.getPage(test_uri)
         assert self.status_code == 401
 
         msg = 'Digest authentification scheme was not found'
@@ -82,16 +84,19 @@ class DigestAuthTest(helper.CPWebCase):
         base_auth = ('Digest username="%s", '
                      'realm="%s", '
                      'nonce="%s", '
-                     'uri="/digest/", '
+                     'uri="%s", '
                      'algorithm=MD5, '
                      'response="%s", '
                      'qop=auth, '
                      'nc=%s, '
                      'cnonce="1522e61005789929"')
 
-        encoded_user = urlencode(username, 'utf-8')
+        encoded_user = username
+        if six.PY3:
+            encoded_user = encoded_user.encode('utf-8')
+        encoded_user = encoded_user.decode('latin1')
         auth_header = base_auth % (
-            encoded_user, realm, nonce,
+            encoded_user, realm, nonce, test_uri,
             '11111111111111111111111111111111', '00000001',
         )
         auth = auth_digest.HttpDigestAuthorization(auth_header, 'GET')
@@ -99,10 +104,10 @@ class DigestAuthTest(helper.CPWebCase):
         ha1 = get_ha1(auth.realm, auth.username)
         response = auth.request_digest(ha1)
         auth_header = base_auth % (
-            encoded_user, realm,
-            nonce, response, '00000001',
+            encoded_user, realm, nonce, test_uri,
+            response, '00000001',
         )
-        self.getPage('/digest/', [('Authorization', auth_header)])
+        self.getPage(test_uri, [('Authorization', auth_header)])
 
     def test_wrong_realm(self):
         # send response with correct response digest, but wrong realm


### PR DESCRIPTION
decoding URIs in auth header breaks e.g. if it contains slashes

* **What kind of change does this PR introduce?**
  - [x] bug fix



* **What is the related issue number (starting with `#`)**

#1716

* **What is the current behavior?** (You can also link to an open issue here)

Authentication loop, see #1716

* **What is the new behavior (if this is a feature change)?**

Authentication, as before 14.2

* **Other information**:


* **Checklist**:

  - [x] I think the code is trivial
