### PR TITLE
Drop support for Python 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,16 @@ jobs:
         ' >> $BASH_ENV
 
     - run: |-
-        for py_ver in 2.7.14 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
+        for py_ver in 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
         do
           pyenv install "$py_ver" &
         done
         wait
-    - run: pyenv global 2.7.14 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
+    - run: pyenv global 3.6.4 3.5.4 3.4.7 pypy3.5-5.10.0
 
     - run: pip install tox tox-pyenv
     - checkout
-    - run: tox -e py27,py34,py35,py36,pypy3 -- -p no:sugar
+    - run: tox -e py34,py35,py36,pypy3 -- -p no:sugar
     - store_test_results:
         path: .test-results
     - store_test_results:
@@ -39,7 +39,7 @@ jobs:
     steps:
     - checkout
     - run: pip install tox
-    - run: tox -e py27,py34,py35,py36
+    - run: tox -e py34,py35,py36
     - store_test_results:
         path: .test-results
     - store_test_results:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ _base_envs:
 - &pyenv_base
   <<: *stage_test
   language: generic
-  python: &pypy2 pypy2.7-5.10.0
   env:
-  - PYTHON_VERSION=pypy2.7-5.10.0
   - &env_pyenv PYENV_ROOT="$HOME/.pyenv"
   - &env_path PATH="$PYENV_ROOT/bin:$PATH"
   before_install:
@@ -75,13 +73,10 @@ _base_envs:
 python:
 - 3.4
 - 3.7-dev
-- *pypy2
 - &pypy3 pypy3.5-5.10.0
 jobs:
   fast_finish: true
   allow_failures:
-  # TODO: check what causes testing stuck
-  - python: *pypy2
   # TODO: fix tests
   - python: *pypy3
   - env: TOXENV=pre-commit-pep257
@@ -97,19 +92,11 @@ jobs:
   - <<: *pure_python_base_priority
     # mainstream here (3.7)
   - <<: *pure_python_base_priority
-    python: 2.7
-  - <<: *pure_python_base_priority
     # mainstream here (3.7)
     # run tests against the bleeding-edge cheroot
     env: TOXENV=cheroot-master
   - <<: *pure_python_base_priority
     python: nightly
-  - <<: *osx_python_base
-    python: 2.7
-    env:
-    - PYTHON_VERSION=2.7.13
-    - *env_pyenv
-    - *env_path
   - <<: *osx_python_base
     python: 3.4
     env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v18.0.0
+-------
+
+* :issue:`1730`: Drop support for Python 2.7. CherryPy 17 will
+  remain an LTS release for bug and security fixes.
+
 v17.4.0
 -------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
   - PYTHON: "C:\\Python36-x64"
   - PYTHON: "C:\\Python35-x64"
   - PYTHON: "C:\\Python34-x64"
-  - PYTHON: "C:\\Python27-x64"
 
 install:
 # symlink python from a directory with a space

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ params = dict(
         'Framework :: CherryPy',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -105,7 +103,7 @@ params = dict(
     setup_requires=[
         'setuptools_scm',
     ],
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=3.4',
 )
 
 


### PR DESCRIPTION
I'm ready to drop support for Python 2.

Systems with moderately recent pip versions (9.x+ and maybe earlier) will not see these releases due to the 'python_version' declaration in the metadata.

Older systems still depending on an unpinned cherrypy will simply need to pin to `CherryPy<18`.

I'm mainly creating this PR so I can ensure the Travis tests are passing (they don't seem to run against the branch).