### PR TITLE
Don't convert bytes headers to str

### DIFF
--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -513,7 +513,7 @@ class HeaderMap(CaseInsensitiveDict):
         transmitting on the wire for HTTP.
         """
         for k, v in header_items:
-            if not isinstance(v, str):
+            if not isinstance(v, str) and not isinstance(v, bytes):
                 v = str(v)
 
             yield tuple(map(cls.encode_header_item, (k, v)))

--- a/cherrypy/test/test_encoding.py
+++ b/cherrypy/test/test_encoding.py
@@ -49,6 +49,8 @@ class EncodingTests(helper.CPWebCase):
                 cherrypy.response.cookie['candy']['domain'] = 'cherrypy.org'
                 cherrypy.response.headers[
                     'Some-Header'] = 'My d\xc3\xb6g has fleas'
+                cherrypy.response.headers[
+                    'Bytes-Header'] = b'Bytes given header'
                 return 'Any content'
 
             @cherrypy.expose
@@ -423,3 +425,8 @@ class EncodingTests(helper.CPWebCase):
     def test_UnicodeHeaders(self):
         self.getPage('/cookies_and_headers')
         self.assertBody('Any content')
+
+    def test_BytesHeaders(self):
+        self.getPage('/cookies_and_headers')
+        self.assertBody('Any content')
+        self.assertHeader('Bytes-Header', 'Bytes given header')


### PR DESCRIPTION
Don't convert bytes header values using str() as str(b'foo') becomes
"b'foo'". Instead just leave bytes as is like it was prior to v18.0.0.

* **What kind of change does this PR introduce?**
  - [x] bug fix