### PR TITLE
Fix all-covering countdown banner in docs

### DIFF
--- a/docs/_templates/python_2_eol.html
+++ b/docs/_templates/python_2_eol.html
@@ -57,7 +57,7 @@
 <script>
   var py2_death = moment('2020-04-12').toDate()
 
-  countdown(py2_death, update_time_left)
+  countdown(py2_death, update_time_left, ~(countdown.SECONDS | countdown.MILLISECONDS))
 
   function update_time_left(moments_left, timer_id) {
     document.querySelector('#python27eol time').innerHTML = moments_left.toHTML("em")

--- a/docs/_templates/python_2_eol.html
+++ b/docs/_templates/python_2_eol.html
@@ -20,7 +20,7 @@
   }
 
   #python27eol {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0; right: 0;
     height:  auto;
@@ -28,16 +28,25 @@
     color: white;
     background-color: black;
     font-size: larger;
-    line-height: 3;
   }
 
-  #python27eol>* {
+  #python27eol * {
     color: white;
     background-color: black;
   }
 
   #python27eol>a {
     display: block;
+  }
+
+  #python27eol>p {
+    padding: 0 100px;
+  }
+
+  @media screen and (max-width: 875px) {
+    #python27eol p {
+      padding: 0;
+    }
   }
 </style>
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?
  - [x] bug fix
  - [ ] feature
  - [x] docs update
  - [ ] tests/coverage improvement
  - [x] refactoring
  - [ ] other



#### What is the related issue number (starting with `#`)
Fixes #1748 


#### What is the current behavior? (You can also link to an open issue here)
The banner of Python 3 countdown covers ~90% of the docs content on mobile devices.


#### What is the new behavior (if this is a feature change)?
The banner is no longer sticking to the top of the page on scroll, so the content is visible.


#### Other information:
I've also removed the seconds from the countdown so that line wouldn't jump.

#### Checklist:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes :)
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
