### PR TITLE
publish should be called when the state is changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v18.1.0
+-------
+
+* :issue:`1758` via :pr:`1759`: In the bus, when awaiting a
+  state change, only publish after the state has changed.
+
 v18.0.1
 -------
 

--- a/cherrypy/process/wspbus.py
+++ b/cherrypy/process/wspbus.py
@@ -375,7 +375,7 @@ class Bus(object):
 
         while self.state not in states:
             time.sleep(interval)
-            self.publish(channel)
+        self.publish(channel)
 
     def _do_execv(self):
         """Re-execute the current process.


### PR DESCRIPTION
publish should not be called during every wait cycle, only after the wait has found the correct state

**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

#1758

**What is the current behavior?** (You can also link to an open issue here)

#1758

**What is the new behavior (if this is a feature change)?**

N/A

**Other information**:


**Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [X] Unit tests for the changes exist
  - [X] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [X] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
