### PR TITLE
CherryPy should handle If-Range's properly

### DIFF
--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -69,7 +69,7 @@ def protocol_from_http(protocol_str):
 
 
 def passes_if_range_check(if_range_header):
-    """Determines if an If-Range header is present and passes its conditions"""
+    """Determines if an If-Range header is present and passes its conditions."""
     if if_range_header:
         # Per RFC:
         # The If-Range HTTP request header makes a range request

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -68,28 +68,24 @@ def protocol_from_http(protocol_str):
     return int(protocol_str[5]), int(protocol_str[7])
 
 
-def passes_if_range_check(if_range_header):
+def matches_if_range_check(if_range_header):
     """Determines if an If-Range header is present and passes its conditions"""
-    if if_range_header:
-        # Per RFC:
-        # The If-Range HTTP request header makes a range request
-        # conditional: if the condition is fulfilled, the range
-        # request will be issued and the server sends back
-        # a 206 Partial Content answer with
-        # the appropriate body. If the condition is not fulfilled,
-        # the full resource is sent back, with a 200 OK status.
-        # Ref: https://tools.ietf.org/html/rfc7233#section-3.2
-        try:
-            if datetime(*parsedate(if_range_header)[:6]) < datetime.now():
-                return True
-            else:
-                return False
-        except TypeError:
-            # Fixme: TypeError indicates that the value is an ETag. We don't support ETag at the moment.
-            return False
-    else:
-        # Return True when there is no If-Range, since it technically fufills all conditions
+    if not if_range_header:
         return True
+    # Per RFC:
+    # The If-Range HTTP request header makes a range request
+    # conditional: if the condition is fulfilled, the range
+    # request will be issued and the server sends back
+    # a 206 Partial Content answer with
+    # the appropriate body. If the condition is not fulfilled,
+    # the full resource is sent back, with a 200 OK status.
+    # Ref: https://tools.ietf.org/html/rfc7233#section-3.2
+    try:
+        return datetime(*parsedate(if_range_header)[:6]) < datetime.now()
+    except TypeError:
+        # Fixme: TypeError indicates that the value is an ETag. We don't support ETag at the moment.
+        return False
+
 
 def get_ranges(headervalue, content_length):
     """Return a list of (start, stop) indices from a Range header, or None.

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -68,7 +68,9 @@ def protocol_from_http(protocol_str):
 
 
 def matches_if_range_check(if_range_header):
-    """Determines if an If-Range header is present and passes its conditions."""
+    """
+    Determines if an If-Range header is present and passes its conditions.
+    """
     if not if_range_header:
         return True
     # Per RFC:
@@ -80,9 +82,11 @@ def matches_if_range_check(if_range_header):
     # the full resource is sent back, with a 200 OK status.
     # Ref: https://tools.ietf.org/html/rfc7233#section-3.2
     try:
-        return datetime(*email.utils.parsedate(if_range_header)[:6]) < datetime.now()
+        return (datetime(*email.utils.parsedate(if_range_header)[:6])
+                < datetime.now())
     except TypeError:
-        # Fixme: TypeError indicates that the value is an ETag. We don't support ETag at the moment.
+        # Fixme: TypeError indicates that the value is an ETag.
+        # We don't support ETag at the moment.
         return False
 
 

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -69,7 +69,7 @@ def protocol_from_http(protocol_str):
 
 
 def matches_if_range_check(if_range_header):
-    """Determines if an If-Range header is present and passes its conditions"""
+    """Determines if an If-Range header is present and passes its conditions."""
     if not if_range_header:
         return True
     # Per RFC:

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -69,7 +69,7 @@ def protocol_from_http(protocol_str):
 
 
 def passes_if_range_check(request):
-    """Return true if the request has If-Range header, and it passes the conditions contained in the header.
+    """Return true if the request does not have an If-Range header, or it passes the conditions contained in the header.
     In this case, the Range header should be observed. False if other, with the Range header discarded."""
     if_range_header = request.headers.get('If-Range')
     if if_range_header:
@@ -84,10 +84,14 @@ def passes_if_range_check(request):
         try:
             if datetime(*parsedate(if_range_header)[:6]) < datetime.now():
                 return True
+            else:
+                return False
         except TypeError:
             # Fixme: TypeError indicates that the value is an ETag. We don't support ETag at the moment.
             return False
-    return False
+    else:
+        # Return True when there is no If-Range, since it technically fufills all conditions
+        return True
 
 def get_ranges(headervalue, content_length):
     """Return a list of (start, stop) indices from a Range header, or None.

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -14,7 +14,6 @@ import builtins
 from binascii import b2a_base64
 from cgi import parse_header
 from datetime import datetime
-from email.utils import parsedate
 from email.header import decode_header
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import unquote_plus
@@ -81,7 +80,7 @@ def matches_if_range_check(if_range_header):
     # the full resource is sent back, with a 200 OK status.
     # Ref: https://tools.ietf.org/html/rfc7233#section-3.2
     try:
-        return datetime(*parsedate(if_range_header)[:6]) < datetime.now()
+        return datetime(*email.utils.parsedate(if_range_header)[:6]) < datetime.now()
     except TypeError:
         # Fixme: TypeError indicates that the value is an ETag. We don't support ETag at the moment.
         return False

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -69,8 +69,7 @@ def protocol_from_http(protocol_str):
 
 
 def passes_if_range_check(request):
-    """Return true if the request does not have an If-Range header, or it passes the conditions contained in the header.
-    In this case, the Range header should be observed. False if other, with the Range header discarded."""
+    """Determines if an If-Range header is present and passes its conditions"""
     if_range_header = request.headers.get('If-Range')
     if if_range_header:
         # Per RFC:

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -68,9 +68,8 @@ def protocol_from_http(protocol_str):
     return int(protocol_str[5]), int(protocol_str[7])
 
 
-def passes_if_range_check(request):
+def passes_if_range_check(if_range_header):
     """Determines if an If-Range header is present and passes its conditions"""
-    if_range_header = request.headers.get('If-Range')
     if if_range_header:
         # Per RFC:
         # The If-Range HTTP request header makes a range request

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -197,7 +197,7 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
                     # Return a multipart/byteranges response.
                     response.status = '206 Partial Content'
                     boundary = make_boundary()
-                    ct = 'multipart/byteranges; boundary=%s' % boundary
+                    ct = 'multipart/byteranges; boundary={}'.format(boundary)
                     response.headers['Content-Type'] = ct
                     if 'Content-Length' in response.headers:
                         # Delete Content-Length header so finalize() recalcs it.

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -1,15 +1,12 @@
 """Module with helpers for serving static files."""
 
-from datetime import datetime
+import mimetypes
 import os
 import platform
 import re
 import stat
-import mimetypes
 import urllib.parse
-
 from email.generator import _make_boundary as make_boundary
-from email.utils import parsedate
 from io import UnsupportedOperation
 
 import cherrypy

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -174,7 +174,8 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
                 content_length
             )
             if r == []:
-                response.headers['Content-Range'] = 'bytes */%s' % content_length
+                response.headers['Content-Range'] = ('bytes '
+                                                     '*/%s' % content_length)
                 message = ('Invalid Range (first-byte-pos greater than '
                            'Content-Length)')
                 if debug:
@@ -234,13 +235,14 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
                     # Apache compatibility:
                     yield b'\r\n'
                 response.body = file_ranges()
+            else:
+                if debug:
+                    log_msg = 'No byteranges requested'
+                    cherrypy.log(log_msg, 'TOOLS.STATIC')
             return response.body
         else:
             if debug:
-                log_msg = (
-                    'If-Range is in the past' if not if_range_valid
-                    else 'No byteranges requested'
-                )
+                log_msg = 'If-Range is in the past'
                 cherrypy.log(log_msg, 'TOOLS.STATIC')
 
     # Set Content-Length and use an iterable (file object)

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -248,7 +248,11 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
             return response.body
         else:
             if debug:
-                cherrypy.log('No byteranges requested or If-Range is in the past', 'TOOLS.STATIC')
+                log_msg = (
+                    'If-Range is in the past' if is_if_range_in_past
+                    else 'No byteranges requested'
+                )
+                cherrypy.log(log_msg, 'TOOLS.STATIC')
 
     # Set Content-Length and use an iterable (file object)
     #   this way CP won't load the whole file in memory

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -201,9 +201,7 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
                     boundary = make_boundary()
                     ct = 'multipart/byteranges; boundary={}'.format(boundary)
                     response.headers['Content-Type'] = ct
-                    if 'Content-Length' in response.headers:
-                        # Delete Content-Length header so finalize() recalcs it.
-                        del response.headers['Content-Length']
+                    response.headers.pop('Content-Length', None)
 
                 def file_ranges():
                     # Apache compatibility:

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -165,7 +165,9 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
     request = cherrypy.serving.request
     if request.protocol >= (1, 1):
         response.headers['Accept-Ranges'] = 'bytes'
-        if_range_valid = httputil.matches_if_range_check(request.headers.get('Range'))
+        if_range_valid = httputil.matches_if_range_check(
+            request.headers.get('Range')
+        )
         if if_range_valid:
             r = httputil.get_ranges(request.headers.get('Range'), content_length)
             if r == []:

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -176,7 +176,7 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
                 cherrypy.log(message, 'TOOLS.STATIC')
             raise cherrypy.HTTPError(416, message)
 
-        IF_RANGE_IN_PAST = False
+        is_if_range_in_past = False
 
         if request.headers.get('If-Range'):
             # Per RFC:
@@ -187,10 +187,10 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
             # the full resource is sent back, with a 200 OK status.
             if datetime.datetime(*parsedate(request.headers.get('If-Range'))[:6]) \
                     < datetime.datetime.now():
-                IF_RANGE_IN_PAST = True
+                is_if_range_in_past = True
 
 
-        if r and not IF_RANGE_IN_PAST:
+        if r and not is_if_range_in_past:
             if len(r) == 1:
                 # Return a single-part response.
                 start, stop = r[0]

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -1,16 +1,16 @@
 """Module with helpers for serving static files."""
 
+import datetime
 import os
 import platform
 import re
 import stat
 import mimetypes
 import urllib.parse
-import datetime
 
 from email.generator import _make_boundary as make_boundary
-from io import UnsupportedOperation
 from email.utils import parsedate
+from io import UnsupportedOperation
 
 import cherrypy
 from cherrypy._cpcompat import ntob

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -164,7 +164,7 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
     request = cherrypy.serving.request
     if request.protocol >= (1, 1):
         response.headers['Accept-Ranges'] = 'bytes'
-        if httputil.passes_if_range_check(request.headers.get('Range')):
+        if httputil.matches_if_range_check(request.headers.get('Range')):
             r = httputil.get_ranges(request.headers.get('Range'), content_length)
             if r == []:
                 response.headers['Content-Range'] = 'bytes */%s' % content_length

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -169,7 +169,10 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
             request.headers.get('Range')
         )
         if if_range_valid:
-            r = httputil.get_ranges(request.headers.get('Range'), content_length)
+            r = httputil.get_ranges(
+                request.headers.get('Range'),
+                content_length
+            )
             if r == []:
                 response.headers['Content-Range'] = 'bytes */%s' % content_length
                 message = ('Invalid Range (first-byte-pos greater than '
@@ -235,7 +238,7 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
         else:
             if debug:
                 log_msg = (
-                    'If-Range is in the past' if resource_expired
+                    'If-Range is in the past' if not if_range_valid
                     else 'No byteranges requested'
                 )
                 cherrypy.log(log_msg, 'TOOLS.STATIC')

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -176,22 +176,7 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
                 cherrypy.log(message, 'TOOLS.STATIC')
             raise cherrypy.HTTPError(416, message)
 
-        is_if_range_in_past = False
-        if_range_header = request.headers.get('If-Range')
-
-        if if_range_header:
-            # Per RFC:
-            # The If-Range HTTP request header makes a range request
-            # conditional: if the condition is fulfilled, the range
-            # request will be issued and the server sends back
-            # a 206 Partial Content answer with
-            # the appropriate body. If the condition is not fulfilled,
-            # the full resource is sent back, with a 200 OK status.
-            # Ref: https://tools.ietf.org/html/rfc7233#section-3.2
-            if datetime(*parsedate(if_range_header)[:6]) < datetime.now():
-                is_if_range_in_past = True
-
-        if r and not is_if_range_in_past:
+        if r and not httputil.passes_if_range_check(request):
             if len(r) == 1:
                 # Return a single-part response.
                 start, stop = r[0]

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -1,6 +1,6 @@
 """Module with helpers for serving static files."""
 
-import datetime
+from datetime import datetime
 import os
 import platform
 import re
@@ -177,16 +177,18 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
             raise cherrypy.HTTPError(416, message)
 
         is_if_range_in_past = False
+        if_range_header = request.headers.get('If-Range')
 
-        if request.headers.get('If-Range'):
+        if if_range_header:
             # Per RFC:
-            # The If-Range HTTP request header makes a range request conditional:
-            # if the condition is fulfilled, the range request will be issued
-            # and the server sends back a 206 Partial Content answer with
+            # The If-Range HTTP request header makes a range request
+            # conditional: if the condition is fulfilled, the range
+            # request will be issued and the server sends back
+            # a 206 Partial Content answer with
             # the appropriate body. If the condition is not fulfilled,
             # the full resource is sent back, with a 200 OK status.
-            if datetime.datetime(*parsedate(request.headers.get('If-Range'))[:6]) \
-                    < datetime.datetime.now():
+            # Ref: https://tools.ietf.org/html/rfc7233#section-3.2
+            if datetime(*parsedate(if_range_header)[:6]) < datetime.now():
                 is_if_range_in_past = True
 
 

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -191,7 +191,6 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
             if datetime(*parsedate(if_range_header)[:6]) < datetime.now():
                 is_if_range_in_past = True
 
-
         if r and not is_if_range_in_past:
             if len(r) == 1:
                 # Return a single-part response.

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -164,7 +164,8 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
     request = cherrypy.serving.request
     if request.protocol >= (1, 1):
         response.headers['Accept-Ranges'] = 'bytes'
-        if httputil.matches_if_range_check(request.headers.get('Range')):
+        if_range_valid = httputil.matches_if_range_check(request.headers.get('Range'))
+        if if_range_valid:
             r = httputil.get_ranges(request.headers.get('Range'), content_length)
             if r == []:
                 response.headers['Content-Range'] = 'bytes */%s' % content_length

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -6,6 +6,7 @@ import platform
 import re
 import stat
 import urllib.parse
+
 from email.generator import _make_boundary as make_boundary
 from io import UnsupportedOperation
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

Fixes #1699 

**What is the current behavior?** (You can also link to an open issue here)

#1699 

**What is the new behavior (if this is a feature change)?**

In the presence of an `If-Range` header, CP will check if the time is before the current time, and if so, return the entire file as opposed to respecting the `Range` header. This is the RFC compliant way to handle this.

**Other information**:


**Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
