### PR TITLE
Correct the loglevel to INFO for sucessful case

### DIFF
--- a/cherrypy/process/win32.py
+++ b/cherrypy/process/win32.py
@@ -28,7 +28,7 @@ class ConsoleCtrlHandler(plugins.SimplePlugin):
             self.bus.log('Could not SetConsoleCtrlHandler (error %r)' %
                          win32api.GetLastError(), level=40)
         else:
-            self.bus.log('Set handler for console events.', level=40)
+            self.bus.log('Set handler for console events.', level=20)
             self.is_set = True
 
     def stop(self):
@@ -46,7 +46,7 @@ class ConsoleCtrlHandler(plugins.SimplePlugin):
             self.bus.log('Could not remove SetConsoleCtrlHandler (error %r)' %
                          win32api.GetLastError(), level=40)
         else:
-            self.bus.log('Removed handler for console events.', level=40)
+            self.bus.log('Removed handler for console events.', level=20)
             self.is_set = False
 
     def handle(self, event):


### PR DESCRIPTION
The below logs are set to ERROR level
   'Set handler for console events.' 
   'Removed handler for console events.'
The logs should be set to INFO level as the logs are added to provided the needed information.

**What kind of change does this PR introduce?**
  - [x] bug fix

**What is the related issue number (starting with `#`)**
Fixes #1762



**What is the current behavior?** (You can also link to an open issue here)
Logs as ERROR in successful return.
https://github.com/cherrypy/cherrypy/issues/1762



**What is the new behavior (if this is a feature change)?**
Logs as INFO in successful return.


**Other information**:


**Checklist**:
  - [x] I think the code is well written

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
