### PR TITLE
fix typo in documentation for CSP header

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -405,7 +405,7 @@ and wrap your entire CherryPy application with it:
        headers = cherrypy.response.headers
        headers['X-Frame-Options'] = 'DENY'
        headers['X-XSS-Protection'] = '1; mode=block'
-       headers['Content-Security-Policy'] = "default-src='self'"
+       headers['Content-Security-Policy'] = "default-src 'self';"
 
 .. note::
 


### PR DESCRIPTION
fixed typo for http CSP header in Advanced, Securing your server documentation

**What kind of change does this PR introduce?**
 Docs update

**What is the related issue number (starting with `#`)**

Documentation for HTTP CSP header

**What is the current behavior?** (You can also link to an open issue here)

What's currently documented produces an error in browser console and does not actually enforce CSP

**What is the new behavior (if this is a feature change)?**

This fixes typo in the documentation