### PR TITLE
Reduced log level for non-error events in win32.py

### DIFF
--- a/cherrypy/process/win32.py
+++ b/cherrypy/process/win32.py
@@ -20,7 +20,7 @@ class ConsoleCtrlHandler(plugins.SimplePlugin):
 
     def start(self):
         if self.is_set:
-            self.bus.log('Handler for console events already set.', level=40)
+            self.bus.log('Handler for console events already set.', level=20)
             return
 
         result = win32api.SetConsoleCtrlHandler(self.handle, 1)
@@ -33,7 +33,7 @@ class ConsoleCtrlHandler(plugins.SimplePlugin):
 
     def stop(self):
         if not self.is_set:
-            self.bus.log('Handler for console events already off.', level=40)
+            self.bus.log('Handler for console events already off.', level=20)
             return
 
         try:


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [x] other



**What is the related issue number (starting with `#`)**
N/A


**What is the current behavior?** (You can also link to an open issue here)
In win32.py's ConsoleCtrlHandler, if start/stop is called multiple times, this is logged at the ERROR (40) level.


**What is the new behavior (if this is a feature change)?**
If start/stop is called multiple times, this is logged at the INFO (20) level.


**Other information**:
Since the code handles the situation well, and there are no side effects to multiple calls, we shouldn't pollute the logs with error level entries.

Also, because ConsoleCtrlHandler is extremely proactive at removing itself (when it captures Ctrl+C or equivalent), even before it attempts to stop the bus, it sometimes ends up that the handler's stop is called multiple times (directly, then via a 'stop' publish event) during normal operations. There's no inherent badness to this, so while it should be noted/logged, it should be logged at a much lower level.

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
