### PR TITLE
Revert "publish should be called when the state is changed"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v18.1.1
+-------
+
+* :pr:`1774` reverts :pr:`1759` as new evidence emerged that
+  the original behavior was intentional. Re-opens :issue:`1758`.
+
 v18.1.0
 -------
 

--- a/cherrypy/process/wspbus.py
+++ b/cherrypy/process/wspbus.py
@@ -374,7 +374,7 @@ class Bus(object):
 
         while self.state not in states:
             time.sleep(interval)
-        self.publish(channel)
+            self.publish(channel)
 
     def _do_execv(self):
         """Re-execute the current process.

--- a/cherrypy/test/test_bus.py
+++ b/cherrypy/test/test_bus.py
@@ -179,12 +179,14 @@ class BusMethodTests(unittest.TestCase):
             time.sleep(0.2)
             getattr(b, method)()
 
-        for method, states in [('start', [b.states.STARTED]),
-                               ('stop', [b.states.STOPPED]),
-                               ('start',
-                                [b.states.STARTING, b.states.STARTED]),
-                               ('exit', [b.states.EXITING]),
-                               ]:
+        flow = [
+            ('start', [b.states.STARTED]),
+            ('stop', [b.states.STOPPED]),
+            ('start', [b.states.STARTING, b.states.STARTED]),
+            ('exit', [b.states.EXITING]),
+        ]
+
+        for method, states in flow:
             threading.Thread(target=f, args=(method,)).start()
             b.wait(states)
 


### PR DESCRIPTION
This reverts commit 20bc9dbf617c61b8c2b7e847d3b88caeabfd6528.

**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

#1759 

**What is the current behavior?** (You can also link to an open issue here)

'main' event doesn't fire periodically on the bus

**What is the new behavior (if this is a feature change)?**

'main' event fires 10x per second

**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
