### PR TITLE
[backport] Fix native WSGI-less HTTP server support under Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v17.4.2 (unreleased)
+--------------------
+
+* Fixed :issue:`1377` by backporting :pr:`1785` via :pr:`1786`:
+  Restore a native WSGI-less HTTP server support.
+
 v17.4.1
 -------
 

--- a/cherrypy/_cpnative_server.py
+++ b/cherrypy/_cpnative_server.py
@@ -9,6 +9,7 @@ import cheroot.server
 import cherrypy
 from cherrypy._cperror import format_exc, bare_error
 from cherrypy.lib import httputil
+from ._cpcompat import tonative
 
 
 class NativeGateway(cheroot.server.Gateway):
@@ -21,21 +22,25 @@ class NativeGateway(cheroot.server.Gateway):
         req = self.req
         try:
             # Obtain a Request object from CherryPy
-            local = req.server.bind_addr
+            local = req.server.bind_addr  # FIXME: handle UNIX sockets
+            local = tonative(local[0]), local[1]
             local = httputil.Host(local[0], local[1], '')
-            remote = req.conn.remote_addr, req.conn.remote_port
+            remote = tonative(req.conn.remote_addr), req.conn.remote_port
             remote = httputil.Host(remote[0], remote[1], '')
 
-            scheme = req.scheme
-            sn = cherrypy.tree.script_name(req.uri or '/')
+            scheme = tonative(req.scheme)
+            sn = cherrypy.tree.script_name(tonative(req.uri or '/'))
             if sn is None:
                 self.send_response('404 Not Found', [], [''])
             else:
                 app = cherrypy.tree.apps[sn]
-                method = req.method
-                path = req.path
-                qs = req.qs or ''
-                headers = req.inheaders.items()
+                method = tonative(req.method)
+                path = tonative(req.path)
+                qs = tonative(req.qs or '')
+                headers = (
+                    (tonative(h), tonative(v))
+                    for h, v in req.inheaders.items()
+                )
                 rfile = req.rfile
                 prev = None
 
@@ -52,8 +57,11 @@ class NativeGateway(cheroot.server.Gateway):
                         # Run the CherryPy Request object and obtain the
                         # response
                         try:
-                            request.run(method, path, qs,
-                                        req.request_protocol, headers, rfile)
+                            request.run(
+                                method, path, qs,
+                                tonative(req.request_protocol),
+                                headers, rfile,
+                            )
                             break
                         except cherrypy.InternalRedirect:
                             ir = sys.exc_info()[1]

--- a/cherrypy/test/test_native.py
+++ b/cherrypy/test/test_native.py
@@ -32,4 +32,7 @@ def cp_native_server(request):
 
 def test_basic_request(cp_native_server):
     """A request to a native server should succeed."""
-    cp_native_server.get('/')
+    resp = cp_native_server.get('/')
+    assert resp.ok
+    assert resp.status_code == 200
+    assert resp.text == 'Hello World!'


### PR DESCRIPTION
This is a backport of #1785.

**What kind of change does this PR introduce?**
  - [x] backport
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other

**What is the related issue number (starting with `#`)**

#1377/#1712/#1784/#1785

**What is the current behavior?** (You can also link to an open issue here)

It's broken under Python 3

**What is the new behavior (if this is a feature change)?**

It works under Python 3

**Other information**:

See #1377

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
