### PR TITLE
HTTP redirect 308

### DIFF
--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -34,6 +34,7 @@ user:
                                               POST should not raise this error
 305      Use Proxy                            Confirm with the user
 307      Temporary Redirect                   Confirm with the user
+308      Moved Permanently                    Confirm with the user
 =====    =================================    ===========
 
 However, browsers have historically implemented these restrictions poorly;
@@ -254,7 +255,7 @@ class HTTPRedirect(CherryPyException):
         response = cherrypy.serving.response
         response.status = status = self.status
 
-        if status in (300, 301, 302, 303, 307):
+        if status in (300, 301, 302, 303, 307, 308):
             response.headers['Content-Type'] = 'text/html;charset=utf-8'
             # "The ... URI SHOULD be given by the Location field
             # in the response."
@@ -269,6 +270,7 @@ class HTTPRedirect(CherryPyException):
                 302: 'This resource resides temporarily at ',
                 303: 'This resource can be found at ',
                 307: 'This resource has moved temporarily to ',
+                308: 'This resource has permanently moved to ',
             }[status]
             msg += '<a href=%s>%s</a>.'
             msgs = [

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -9,7 +9,7 @@ Not Modified if possible, or serve the cached response otherwise. It also sets
 request.cached to True if serving a cached representation, and sets
 request.cacheable to False (so it doesn't get cached again).
 
-If POST, PUT, PATCH or DELETE requests are made for a cached resource, they
+If POST, PUT or DELETE requests are made for a cached resource, they
 invalidate (delete) any cached response.
 
 Usage
@@ -265,10 +265,10 @@ class MemoryCache(Cache):
         self.store.pop(uri, None)
 
 
-def get(invalid_methods=('POST', 'PUT', 'DELETE', 'PATCH'), debug=False, **kwargs):
+def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
     """Try to obtain cached output. If fresh enough, raise HTTPError(304).
 
-    If POST, PUT, PATCH or DELETE:
+    If POST, PUT or DELETE:
         * invalidates (deletes) any cached response for this resource
         * sets request.cached = False
         * sets request.cacheable = False
@@ -300,7 +300,7 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE', 'PATCH'), debug=False, **kwarg
             setattr(cherrypy._cache, k, v)
         cherrypy._cache.debug = debug
 
-    # POST, PUT, PATCH, DELETE should invalidate (delete) the cached copy.
+    # POST, PUT, DELETE should invalidate (delete) the cached copy.
     # See http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.10.
     if request.method in invalid_methods:
         if debug:

--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -9,7 +9,7 @@ Not Modified if possible, or serve the cached response otherwise. It also sets
 request.cached to True if serving a cached representation, and sets
 request.cacheable to False (so it doesn't get cached again).
 
-If POST, PUT, or DELETE requests are made for a cached resource, they
+If POST, PUT, PATCH or DELETE requests are made for a cached resource, they
 invalidate (delete) any cached response.
 
 Usage
@@ -265,10 +265,10 @@ class MemoryCache(Cache):
         self.store.pop(uri, None)
 
 
-def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
+def get(invalid_methods=('POST', 'PUT', 'DELETE', 'PATCH'), debug=False, **kwargs):
     """Try to obtain cached output. If fresh enough, raise HTTPError(304).
 
-    If POST, PUT, or DELETE:
+    If POST, PUT, PATCH or DELETE:
         * invalidates (deletes) any cached response for this resource
         * sets request.cached = False
         * sets request.cacheable = False
@@ -300,7 +300,7 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
             setattr(cherrypy._cache, k, v)
         cherrypy._cache.debug = debug
 
-    # POST, PUT, DELETE should invalidate (delete) the cached copy.
+    # POST, PUT, PATCH, DELETE should invalidate (delete) the cached copy.
     # See http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.10.
     if request.method in invalid_methods:
         if debug:


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [x] bug fix
  - [x] feature

**What is the current behavior?** (You can also link to an open issue here)
Cherrypy currently lacks a HTTP redirect 308



**What is the new behavior (if this is a feature change)?**
Adds a redirect 308 option to _cperror.py

