### PR TITLE
Support 308 Permanent Redirect HTTP redirect

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v18.2.0dev
+----------
+
+* :pr:`1794`: Add native support for ``308 Permanent Redirect``
+  usable via ``raise cherrypy.HTTPRedirect('/new_uri', 308)``.
+
 v18.1.2
 -------
 

--- a/cherrypy/_cperror.py
+++ b/cherrypy/_cperror.py
@@ -34,6 +34,7 @@ user:
                                               POST should not raise this error
 305      Use Proxy                            Confirm with the user
 307      Temporary Redirect                   Confirm with the user
+308      Permanent Redirect                   No confirmation
 =====    =================================    ===========
 
 However, browsers have historically implemented these restrictions poorly;
@@ -254,7 +255,7 @@ class HTTPRedirect(CherryPyException):
         response = cherrypy.serving.response
         response.status = status = self.status
 
-        if status in (300, 301, 302, 303, 307):
+        if status in (300, 301, 302, 303, 307, 308):
             response.headers['Content-Type'] = 'text/html;charset=utf-8'
             # "The ... URI SHOULD be given by the Location field
             # in the response."
@@ -269,6 +270,7 @@ class HTTPRedirect(CherryPyException):
                 302: 'This resource resides temporarily at ',
                 303: 'This resource can be found at ',
                 307: 'This resource has moved temporarily to ',
+                308: 'This resource has been moved to ',
             }[status]
             msg += '<a href=%s>%s</a>.'
             msgs = [

--- a/cherrypy/test/test_core.py
+++ b/cherrypy/test/test_core.py
@@ -385,6 +385,11 @@ class CoreRequestHandlingTest(helper.CPWebCase):
             r"<a href=(['\"])(.*)somewhere%20else\1>\2somewhere%20else</a>")
         self.assertStatus(307)
 
+        self.getPage('/redirect/by_code?code=308')
+        self.assertMatchesBody(
+            r"<a href=(['\"])(.*)somewhere%20else\1>\2somewhere%20else</a>")
+        self.assertStatus(308)
+
         self.getPage('/redirect/nomodify')
         self.assertBody('')
         self.assertStatus(304)


### PR DESCRIPTION
Recognize ``raise cherrypy.HTTPRedirect('/new_uri', 308)`` as a legitimate redirect.

Refs:
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308#Status
* https://tools.ietf.org/html/rfc7538#section-3
* https://airbrake.io/blog/http-errors/308-permanent-redirect
* https://stackoverflow.com/a/42138726/595220


**What kind of change does this PR introduce?**
  - [x] bug fix
  - [x] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other

**What is the related issue number (starting with `#`)**

N/A

**What is the current behavior?** (You can also link to an open issue here)

`raise cherrypy.HTTPRedirect('/new_uri', 308)` is not recognized as a redirect and causes a `ValueError`

**What is the new behavior (if this is a feature change)?**

`raise cherrypy.HTTPRedirect('/new_uri', 308)` works the same way as other HTTP codes for redirection.

**Other information**:

N/A

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit