### PR TITLE
Invalidate cache on PATCH request

### DIFF
--- a/cherrypy/lib/caching.py
+++ b/cherrypy/lib/caching.py
@@ -9,7 +9,7 @@ Not Modified if possible, or serve the cached response otherwise. It also sets
 request.cached to True if serving a cached representation, and sets
 request.cacheable to False (so it doesn't get cached again).
 
-If POST, PUT, or DELETE requests are made for a cached resource, they
+If POST, PUT, PATCH or DELETE requests are made for a cached resource, they
 invalidate (delete) any cached response.
 
 Usage
@@ -265,10 +265,10 @@ class MemoryCache(Cache):
         self.store.pop(uri, None)
 
 
-def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
+def get(invalid_methods=('POST', 'PUT', 'PATCH', 'DELETE'), debug=False, **kwargs):
     """Try to obtain cached output. If fresh enough, raise HTTPError(304).
 
-    If POST, PUT, or DELETE:
+    If POST, PUT, PATCH or DELETE:
         * invalidates (deletes) any cached response for this resource
         * sets request.cached = False
         * sets request.cacheable = False
@@ -300,7 +300,7 @@ def get(invalid_methods=('POST', 'PUT', 'DELETE'), debug=False, **kwargs):
             setattr(cherrypy._cache, k, v)
         cherrypy._cache.debug = debug
 
-    # POST, PUT, DELETE should invalidate (delete) the cached copy.
+    # POST, PUT, PATCH, DELETE should invalidate (delete) the cached copy.
     # See http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.10.
     if request.method in invalid_methods:
         if debug:

--- a/cherrypy/test/test_caching.py
+++ b/cherrypy/test/test_caching.py
@@ -154,7 +154,7 @@ class CacheTest(helper.CPWebCase):
                 self.assert_(age >= elapsed)
                 elapsed = age
 
-        # POST, PUT, DELETE should not be cached.
+        # POST, PUT, PATCH, DELETE should not be cached.
         self.getPage('/', method='POST')
         self.assertBody('visit #2')
         # Because gzip is turned on, the Vary header should always Vary for


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
N.a.


**What is the current behaviour?** (You can also link to an open issue here)
On a PATCH request the related cached responses are not invalidated


**What is the new behaviour (if this is a feature change)?**
On a PATCH request the related cached responses will be invalidated


**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
