### PR TITLE
fix RamSession Cleanup Thread Death #1803

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -404,18 +404,28 @@ class RamSession(Session):
         """Clean up expired sessions."""
 
         now = self.now()
-        for _id, (data, expiration_time) in list(self.cache.items()):
-            if expiration_time <= now:
-                try:
-                    del self.cache[_id]
-                except KeyError:
-                    pass
-                try:
-                    if self.locks[_id].acquire(blocking=False):
-                        lock = self.locks.pop(_id)
-                        lock.release()
-                except KeyError:
-                    pass
+        try:
+            for _id, (data, expiration_time) in list(self.cache.items()):
+                if expiration_time <= now:
+                    try:
+                        del self.cache[_id]
+                    except KeyError:
+                        pass
+                    try:
+                        if self.locks[_id].acquire(blocking=False):
+                            lock = self.locks.pop(_id)
+                            lock.release()
+                    except KeyError:
+                        pass
+
+        except RuntimeError:
+            """Under heavy load, list(self.cache.items()) will occasionally raise this
+            error for large session caches with message
+            "dictionary changed size during iteration"
+            Better to pause the cleanup than to let the cleanup thread die.
+            """
+
+            return
 
         # added to remove obsolete lock objects
         for _id in list(self.locks):


### PR DESCRIPTION
So the cleanup thread doesn't die

**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

Fixes #1803


**What is the current behavior?** (You can also link to an open issue here)

#1803


**What is the new behavior (if this is a feature change)?**

cleanup thread survives `RuntimeError`

**Other information**:

`test_session.test_8_Ram_Cleanup` covers the function but I'm not sure how you could generate the exception in a test environment.

The other, more general way to fix this would be to change line 301 in `lib.sessions` from `if self.clean_freq and not cls.clean_thread` to `if self.clean_freq and (not cls.clean_thread or not cls.clean_thread.is_alive())` but I do not know the code well enough to judge whether this is overkill.

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [?] Unit tests for the changes exist
  - [?] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
