### PR TITLE
Bypass security checks leading to failed tests on late Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,6 @@ jobs:
   # TODO: fix tests
   - python: *pypy3
   - env: TOXENV=pre-commit-pep257
-  - python: nightly
   include:
   - <<: *lint_python_base
     env: TOXENV=pre-commit

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -6,7 +6,7 @@ import re
 import platform
 import tempfile
 import urllib.parse
-import http.client
+import unittest.mock
 from http.client import HTTPConnection
 
 import pytest
@@ -399,8 +399,12 @@ class StaticTest(helper.CPWebCase):
         self.assertStatus(404)
         self.assertInBody("I couldn't find that thing")
 
+    @unittest.mock.patch(
+        'http.client._contains_disallowed_url_pchar_re',
+        re.compile(r'[\n]'),
+        create=True,
+    )
     def test_null_bytes(self):
-        http.client._contains_disallowed_url_pchar_re = re.compile(r'[\n]')
         self.getPage('/static/\x00')
         self.assertStatus('404 Not Found')
 

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -2,9 +2,11 @@
 import io
 import os
 import sys
+import re
 import platform
 import tempfile
 import urllib.parse
+import http.client
 from http.client import HTTPConnection
 
 import pytest
@@ -398,6 +400,7 @@ class StaticTest(helper.CPWebCase):
         self.assertInBody("I couldn't find that thing")
 
     def test_null_bytes(self):
+        http.client._contains_disallowed_url_pchar_re = re.compile(r'[\n]')
         self.getPage('/static/\x00')
         self.assertStatus('404 Not Found')
 


### PR DESCRIPTION
Fixes #1781
