### PR TITLE
Refer enterprise customers to Tidelift for commercial support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,17 @@ If the docs are insufficient to address your needs, the CherryPy
 community has several `avenues for support
 <https://docs.cherrypy.org/en/latest/support.html>`_.
 
+For Enterprise
+--------------
+
+CherryPy is available as part of the Tidelift Subscription.
+
+The CherryPy maintainers and the maintainers of thousands of other packages
+are working with Tidelift to deliver one enterprise subscription that covers
+all of the open source you use.
+
+`Learn more <https://tidelift.com/subscription/pkg/pypi-cherrypy?utm_source=pypi-cherrypy&utm_medium=referral&utm_campaign=github>`_.
+
 Contributing
 ------------
 

--- a/docs/enterprise.rst
+++ b/docs/enterprise.rst
@@ -1,3 +1,6 @@
+.. todo: consider linking to the same text in README.rst.
+.. https://github.com/cherrypy/cherrypy/pull/1813#discussion_r330805322
+
 For Enterprise
 ==============
 

--- a/docs/enterprise.rst
+++ b/docs/enterprise.rst
@@ -1,0 +1,10 @@
+For Enterprise
+==============
+
+CherryPy is available as part of the Tidelift Subscription.
+
+The CherryPy maintainers and the maintainers of thousands of other packages
+are working with Tidelift to deliver one enterprise subscription that covers
+all of the open source you use.
+
+`Learn more <https://tidelift.com/subscription/pkg/pypi-cherrypy?utm_source=pypi-cherrypy&utm_medium=referral&utm_campaign=github>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ CherryPy — A Minimalist Python Web Framework
    extend.rst
    deploy.rst
    support.rst
+   enterprise.rst
    contribute.rst
    development.rst
    glossary.rst


### PR DESCRIPTION
Alongside cherrypy/cherrypy.github.io#8, this PR updates the documentation and README to refer potential commercial clients to commercial support offerings through Tidelift.