### PR TITLE
Fixed a Sphinx warning in 'here' anchor

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -568,7 +568,8 @@ to integrate common database interfaces such as the DB-API specified in
 <http://sqlalchemy.readthedocs.org>`_ or `SQLObject
 <https://pypi.python.org/pypi/SQLObject/>`_.
 
-You will find a recipie at `SQL_Alchemy <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
+You will find a recipe at `cherrypy-recipes
+ <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
 that explains how to integrate SQLAlchemy using a mix of
 :ref:`plugins <busplugins>` and :ref:`tools <tools>`.
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -568,8 +568,8 @@ to integrate common database interfaces such as the DB-API specified in
 <http://sqlalchemy.readthedocs.org>`_ or `SQLObject
 <https://pypi.python.org/pypi/SQLObject/>`_.
 
-You will find `here <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
-a recipe on how integrating SQLAlchemy using a mix of
+You will find a recipie at `SQL_Alchemy <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
+that explains how to integrate SQLAlchemy using a mix of
 :ref:`plugins <busplugins>` and :ref:`tools <tools>`.
 
 HTML Templating support


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [x] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
#1797

**What is the current behavior?** (You can also link to an open issue here)
 #1797
This is just fixing one of the warnings where 'here' was overloaded in the documentation. 


**What is the new behavior (if this is a feature change)?**
'here' was replaced with a different string to prevent the warning

**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
