### PR TITLE
fixed some more documentation warnings

### DIFF
--- a/cherrypy/lib/cptools.py
+++ b/cherrypy/lib/cptools.py
@@ -404,21 +404,20 @@ Message: %(error_msg)s
 
 
 def session_auth(**kwargs):
+    """Session authentication hook.
+
+    Any attribute of the SessionAuth class may be overridden
+    via a keyword arg to this function:
+
+    """ + '\n'.join(
+        '{!s}: {!s}'.format(k, type(getattr(SessionAuth, k)).__name__)
+        for k in dir(SessionAuth)
+        if not k.startswith('__')
+    )
     sa = SessionAuth()
     for k, v in kwargs.items():
         setattr(sa, k, v)
     return sa.run()
-
-
-session_auth.__doc__ = (
-    """Session authentication hook.
-
-    Any attribute of the SessionAuth class may be overridden via a keyword arg
-    to this function:
-
-    """ + '\n'.join(['%s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
-                     for k in dir(SessionAuth) if not k.startswith('__')])
-)
 
 
 def log_traceback(severity=logging.ERROR, debug=False):

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -569,7 +569,7 @@ to integrate common database interfaces such as the DB-API specified in
 <https://pypi.python.org/pypi/SQLObject/>`_.
 
 You will find a recipe at `cherrypy-recipes
- <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
+<https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
 that explains how to integrate SQLAlchemy using a mix of
 :ref:`plugins <busplugins>` and :ref:`tools <tools>`.
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -579,7 +579,7 @@ it is distributed and a good choice if you want to
 share sessions outside of the process running CherryPy.
 
 Requires that the Python
-`memcached <https://pypi.org/project/memcached>`_
+`memcached <https://pypi.org/project/memcached>`__
 package is installed, which may be indicated by installing
 ``cherrypy[memcached_session]``.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [x] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other

**What is the related issue number (starting with `#`)**

#1797

**What is the current behavior?** (You can also link to an open issue here)

cherrypy/lib/cptools.py: Warning on block indents and unexpected unindents.
docs/advanced.rst: Warning on newline in comment
docs/basic.rst: Warning for 'memecached' duplicated 

**What is the new behavior (if this is a feature change)?**

Fixed warnings

**Other information**:

N/A

**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
