### PR TITLE
Fix test_HTTP11_Timeout_after_request to expect 408 responses

### DIFF
--- a/cherrypy/test/test_conn.py
+++ b/cherrypy/test/test_conn.py
@@ -390,12 +390,10 @@ class PipelineTests(helper.CPWebCase):
         except Exception:
             if not isinstance(sys.exc_info()[1],
                               (socket.error, BadStatusLine)):
-                self.fail("Writing to timed out socket didn't fail"
-                          ' as it should have: %s' % sys.exc_info()[1])
+                self.fail(msg % sys.exc_info()[1])
         else:
-            self.fail("Writing to timed out socket didn't fail"
-                      ' as it should have: %s' %
-                      response.read())
+            if response.status != 408:
+                self.fail(msg % response.read())
 
         conn.close()
 

--- a/cherrypy/test/test_conn.py
+++ b/cherrypy/test/test_conn.py
@@ -314,7 +314,6 @@ class PipelineTests(helper.CPWebCase):
         self.assertEqual(response.status, 408)
         conn.close()
 
-    @pytest.mark.xfail(reason='cherrypy#1817')
     def test_HTTP11_Timeout_after_request(self):
         # If we timeout after at least one request has succeeded,
         # the server will close the conn without 408.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

#1817 

**What is the current behavior?** (You can also link to an open issue here)

Test fails.

**What is the new behavior (if this is a feature change)?**

Test passes!

**Other information**:

The changes in cheroot now mean that we're better at writing a 408 response to indicate that the time waiting for a request has timed out - it's just that the underlying test in CherryPy wasn't expecting this consistent behaviour, and so expected a 408 response in some circumstances and a socket error in others.