### PR TITLE
Pass arguments from CPWebCase.getPage to WebCase.getPage without replicating signature. 

### DIFF
--- a/cherrypy/test/helper.py
+++ b/cherrypy/test/helper.py
@@ -310,19 +310,12 @@ class CPWebCase(webtest.WebCase):
     def exit(self):
         sys.exit()
 
-    def getPage(self, url, headers=None, method='GET', body=None,
-                protocol=None, raise_subcls=None):
-        """Open the url. Return status, headers, body.
-
-        `raise_subcls` must be a tuple with the exceptions classes
-        or a single exception class that are not going to be considered
-        a socket.error regardless that they were are subclass of a
-        socket.error and therefore not considered for a connection retry.
+    def getPage(self, url, *args, **kwargs):
+        """Open the url.
         """
         if self.script_name:
             url = httputil.urljoin(self.script_name, url)
-        return webtest.WebCase.getPage(self, url, headers, method, body,
-                                       protocol, raise_subcls)
+        return webtest.WebCase.getPage(self, url, *args, **kwargs)
 
     def skip(self, msg='skipped '):
         pytest.skip(msg)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ params = dict(
     entry_points={'console_scripts': ['cherryd = cherrypy.__main__:run']},
     include_package_data=True,
     install_requires=[
-        'cheroot>=6.2.4',
+        'cheroot>=8.2.1',
         'portend>=2.1.1',
         'more_itertools',
         'zc.lockfile',


### PR DESCRIPTION
Ref #1818.

This change simplifies the code and avoids coupling the two function call signatures.

Because it bumps the cheroot dependency to 8.2.1, I want to wait some time (2 weeks) before requiring that dependency.