### PR TITLE
Docs updating: Session Auth Subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,13 +118,13 @@ v16.0.0
   ``digest_auth`` tools and the ``httpauth`` module, which have been
   officially deprecated earlier in v14.0.0.
 
-* Removed deprecated properties::
+* Removed deprecated properties:
 
   - ``cherrypy._cpreqbody.Entity.type`` deprecated in favor of
     :py:attr:`cherrypy._cpreqbody.Entity.content_type`
 
   - ``cherrypy._cprequest.Request.body_params`` deprecated in favor of
-    py:attr:`cherrypy._cprequest.RequestBody.params`
+    :py:attr:`cherrypy._cprequest.RequestBody.params`
 
 * :issue:`1377`: In _cp_native server, set ``req.status`` using bytes
   (fixed in :pr:`1712`).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,13 +112,13 @@ v16.0.0
   ``digest_auth`` tools and the ``httpauth`` module, which have been
   officially deprecated earlier in v14.0.0.
 
-* Removed deprecated properties::
+* Removed deprecated properties:
 
   - ``cherrypy._cpreqbody.Entity.type`` deprecated in favor of
     :py:attr:`cherrypy._cpreqbody.Entity.content_type`
 
   - ``cherrypy._cprequest.Request.body_params`` deprecated in favor of
-    py:attr:`cherrypy._cprequest.RequestBody.params`
+    :py:attr:`cherrypy._cprequest.RequestBody.params`
 
 * :issue:`1377`: In _cp_native server, set ``req.status`` using bytes
   (fixed in :pr:`1712`).

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -82,7 +82,9 @@ def popargs(*args, **kwargs):
 
     This decorator may be used in one of two ways:
 
-    As a class decorator::
+    As a class decorator:
+
+    .. code-block:: python
 
         @cherrypy.popargs('year', 'month', 'day')
         class Blog:
@@ -92,10 +94,12 @@ def popargs(*args, **kwargs):
                 #will fill in the appropriate parameters.
 
             def create(self):
-                #This link will still be available at /create.  Defined functions
-                #take precedence over arguments.
+                #This link will still be available at /create.
+                #Defined functions take precedence over arguments.
 
-    Or as a member of a class::
+    Or as a member of a class:
+
+    .. code-block:: python
 
         class Blog:
             _cp_dispatch = cherrypy.popargs('year', 'month', 'day')
@@ -103,7 +107,9 @@ def popargs(*args, **kwargs):
 
     The handler argument may be used to mix arguments with built in functions.
     For instance, the following setup allows different activities at the
-    day, month, and year level::
+    day, month, and year level:
+
+    .. code-block:: python
 
         class DayHandler:
             def index(self, year, month, day):

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -82,53 +82,55 @@ def popargs(*args, **kwargs):
 
     This decorator may be used in one of two ways:
 
-    As a class decorator:
-    @cherrypy.popargs('year', 'month', 'day')
-    class Blog:
-        def index(self, year=None, month=None, day=None):
-            #Process the parameters here; any url like
-            #/, /2009, /2009/12, or /2009/12/31
-            #will fill in the appropriate parameters.
+    As a class decorator::
 
-        def create(self):
-            #This link will still be available at /create.  Defined functions
-            #take precedence over arguments.
+        @cherrypy.popargs('year', 'month', 'day')
+        class Blog:
+            def index(self, year=None, month=None, day=None):
+                #Process the parameters here; any url like
+                #/, /2009, /2009/12, or /2009/12/31
+                #will fill in the appropriate parameters.
 
-    Or as a member of a class:
-    class Blog:
-        _cp_dispatch = cherrypy.popargs('year', 'month', 'day')
-        #...
+            def create(self):
+                #This link will still be available at /create.  Defined functions
+                #take precedence over arguments.
+
+    Or as a member of a class::
+
+        class Blog:
+            _cp_dispatch = cherrypy.popargs('year', 'month', 'day')
+            #...
 
     The handler argument may be used to mix arguments with built in functions.
     For instance, the following setup allows different activities at the
-    day, month, and year level:
+    day, month, and year level::
 
-    class DayHandler:
-        def index(self, year, month, day):
-            #Do something with this day; probably list entries
+        class DayHandler:
+            def index(self, year, month, day):
+                #Do something with this day; probably list entries
 
-        def delete(self, year, month, day):
-            #Delete all entries for this day
+            def delete(self, year, month, day):
+                #Delete all entries for this day
 
-    @cherrypy.popargs('day', handler=DayHandler())
-    class MonthHandler:
-        def index(self, year, month):
-            #Do something with this month; probably list entries
+        @cherrypy.popargs('day', handler=DayHandler())
+        class MonthHandler:
+            def index(self, year, month):
+                #Do something with this month; probably list entries
 
-        def delete(self, year, month):
-            #Delete all entries for this month
+            def delete(self, year, month):
+                #Delete all entries for this month
 
-    @cherrypy.popargs('month', handler=MonthHandler())
-    class YearHandler:
-        def index(self, year):
-            #Do something with this year
+        @cherrypy.popargs('month', handler=MonthHandler())
+        class YearHandler:
+            def index(self, year):
+                #Do something with this year
 
-        #...
-
-    @cherrypy.popargs('year', handler=YearHandler())
-    class Root:
-        def index(self):
             #...
+
+        @cherrypy.popargs('year', handler=YearHandler())
+        class Root:
+            def index(self):
+                #...
 
     """
     # Since keyword arg comes after *args, we have to process it ourselves

--- a/cherrypy/lib/cptools.py
+++ b/cherrypy/lib/cptools.py
@@ -410,12 +410,15 @@ def session_auth(**kwargs):
     return sa.run()
 
 
+session_auth_subclasses = (
+    '* {!s}: {!s}'.format(k, type(getattr(SessionAuth, k)).__name__)
+    for k in dir(SessionAuth) if not k.startswith('__')
+)
 session_auth.__doc__ = (
     """Session authentication hook.
     Any attribute of the SessionAuth class may be overridden via a keyword arg
     to this function:
-    """ + '\n'.join(['%s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
-                     for k in dir(SessionAuth) if not k.startswith('__')])
+    """ + '\n    '.join(session_auth_subclasses)
 )
 
 

--- a/cherrypy/lib/cptools.py
+++ b/cherrypy/lib/cptools.py
@@ -416,7 +416,7 @@ session_auth.__doc__ = (
     Any attribute of the SessionAuth class may be overridden via a keyword arg
     to this function:
 
-    """ + '\n'.join(['%s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
+    """ + '\n    '.join(['* %s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
                      for k in dir(SessionAuth) if not k.startswith('__')])
 )
 

--- a/cherrypy/lib/cptools.py
+++ b/cherrypy/lib/cptools.py
@@ -410,14 +410,15 @@ def session_auth(**kwargs):
     return sa.run()
 
 
+keyword_args = ['* %s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
+                for k in dir(SessionAuth) if not k.startswith('__')]
 session_auth.__doc__ = (
     """Session authentication hook.
 
     Any attribute of the SessionAuth class may be overridden via a keyword arg
     to this function:
 
-    """ + '\n    '.join(['* %s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
-                     for k in dir(SessionAuth) if not k.startswith('__')])
+    """ + '\n    '.join(keyword_args)
 )
 
 

--- a/cherrypy/lib/cptools.py
+++ b/cherrypy/lib/cptools.py
@@ -410,15 +410,12 @@ def session_auth(**kwargs):
     return sa.run()
 
 
-keyword_args = ['* %s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
-                for k in dir(SessionAuth) if not k.startswith('__')]
 session_auth.__doc__ = (
     """Session authentication hook.
-
     Any attribute of the SessionAuth class may be overridden via a keyword arg
     to this function:
-
-    """ + '\n    '.join(keyword_args)
+    """ + '\n'.join(['%s: %s' % (k, type(getattr(SessionAuth, k)).__name__)
+                     for k in dir(SessionAuth) if not k.startswith('__')])
 )
 
 

--- a/cherrypy/test/modwsgi.py
+++ b/cherrypy/test/modwsgi.py
@@ -9,18 +9,18 @@ create a symlink to them if needed.
 KNOWN BUGS
 ==========
 
-##1. Apache processes Range headers automatically; CherryPy's truncated
-##    output is then truncated again by Apache. See test_core.testRanges.
-##    This was worked around in http://www.cherrypy.org/changeset/1319.
+1. Apache processes Range headers automatically; CherryPy's truncated
+    output is then truncated again by Apache. See test_core.testRanges.
+    This was worked around in http://www.cherrypy.org/changeset/1319.
 2. Apache does not allow custom HTTP methods like CONNECT as per the spec.
     See test_core.testHTTPMethods.
 3. Max request header and body settings do not work with Apache.
-##4. Apache replaces status "reason phrases" automatically. For example,
-##    CherryPy may set "304 Not modified" but Apache will write out
-##    "304 Not Modified" (capital "M").
-##5. Apache does not allow custom error codes as per the spec.
-##6. Apache (or perhaps modpython, or modpython_gateway) unquotes %xx in the
-##    Request-URI too early.
+4. Apache replaces status "reason phrases" automatically. For example,
+    CherryPy may set "304 Not modified" but Apache will write out
+    "304 Not Modified" (capital "M").
+5. Apache does not allow custom error codes as per the spec.
+6. Apache (or perhaps modpython, or modpython_gateway) unquotes %xx in the
+    Request-URI too early.
 7. mod_wsgi will not read request bodies which use the "chunked"
     transfer-coding (it passes REQUEST_CHUNKED_ERROR to ap_setup_client_block
     instead of REQUEST_CHUNKED_DECHUNK, see Apache2's http_protocol.c and

--- a/cherrypy/test/test_http.py
+++ b/cherrypy/test/test_http.py
@@ -187,6 +187,7 @@ class HTTPTests(helper.CPWebCase):
     def test_post_filename_with_special_characters(self):
         '''Testing that we can handle filenames with special characters. This
         was reported as a bug in:
+
            https://github.com/cherrypy/cherrypy/issues/1146/
            https://github.com/cherrypy/cherrypy/issues/1397/
            https://github.com/cherrypy/cherrypy/issues/1694/

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -568,9 +568,8 @@ to integrate common database interfaces such as the DB-API specified in
 <http://sqlalchemy.readthedocs.org>`_ or `SQLObject
 <https://pypi.python.org/pypi/SQLObject/>`_.
 
-You will find a recipe at `cherrypy-recipes
- <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
-that explains how to integrate SQLAlchemy using a mix of
+Here is a `recipe <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
+on how integrating SQLAlchemy using a mix of
 :ref:`plugins <busplugins>` and :ref:`tools <tools>`.
 
 HTML Templating support

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -568,8 +568,8 @@ to integrate common database interfaces such as the DB-API specified in
 <http://sqlalchemy.readthedocs.org>`_ or `SQLObject
 <https://pypi.python.org/pypi/SQLObject/>`_.
 
-You will find `here <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
-a recipe on how integrating SQLAlchemy using a mix of
+Here is a `recipe <https://bitbucket.org/Lawouach/cherrypy-recipes/src/tip/web/database/sql_alchemy/>`_
+on how integrating SQLAlchemy using a mix of
 :ref:`plugins <busplugins>` and :ref:`tools <tools>`.
 
 HTML Templating support

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -579,8 +579,8 @@ it is distributed and a good choice if you want to
 share sessions outside of the process running CherryPy.
 
 Requires that the Python
-`memcached <https://pypi.org/project/memcached>`_
-package is installed, which may be indicated by installing
+`memcached package <https://pypi.org/project/memcached>`_
+is installed, which may be indicated by installing
 ``cherrypy[memcached_session]``.
 
 .. code-block:: ini


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [x] docs update
  - [ ] tests/coverage improvement
  - [x] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

#1797 and #1812 

**What is the current behavior?** (You can also link to an open issue here)

Docs build with sphinx warnings

**What is the new behavior (if this is a feature change)?**

One particular section of `cherrypy/lib/cptools.py` is updated to have documentation display better, while using a generator expression instead of an in memory list.

**Other information**:

If #1812 is merged first, there is only one file in this PR that is actually modified

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
