### PR TITLE
Address several trivial Sphinx warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,13 +118,13 @@ v16.0.0
   ``digest_auth`` tools and the ``httpauth`` module, which have been
   officially deprecated earlier in v14.0.0.
 
-* Removed deprecated properties::
+* Removed deprecated properties:
 
   - ``cherrypy._cpreqbody.Entity.type`` deprecated in favor of
     :py:attr:`cherrypy._cpreqbody.Entity.content_type`
 
   - ``cherrypy._cprequest.Request.body_params`` deprecated in favor of
-    py:attr:`cherrypy._cprequest.RequestBody.params`
+    :py:attr:`cherrypy._cprequest.RequestBody.params`
 
 * :issue:`1377`: In _cp_native server, set ``req.status`` using bytes
   (fixed in :pr:`1712`).

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -83,52 +83,60 @@ def popargs(*args, **kwargs):
     This decorator may be used in one of two ways:
 
     As a class decorator:
-    @cherrypy.popargs('year', 'month', 'day')
-    class Blog:
-        def index(self, year=None, month=None, day=None):
-            #Process the parameters here; any url like
-            #/, /2009, /2009/12, or /2009/12/31
-            #will fill in the appropriate parameters.
 
-        def create(self):
-            #This link will still be available at /create.  Defined functions
-            #take precedence over arguments.
+    .. code-block:: python
+
+        @cherrypy.popargs('year', 'month', 'day')
+        class Blog:
+            def index(self, year=None, month=None, day=None):
+                #Process the parameters here; any url like
+                #/, /2009, /2009/12, or /2009/12/31
+                #will fill in the appropriate parameters.
+
+            def create(self):
+                #This link will still be available at /create.
+                #Defined functions take precedence over arguments.
 
     Or as a member of a class:
-    class Blog:
-        _cp_dispatch = cherrypy.popargs('year', 'month', 'day')
-        #...
+
+    .. code-block:: python
+
+        class Blog:
+            _cp_dispatch = cherrypy.popargs('year', 'month', 'day')
+            #...
 
     The handler argument may be used to mix arguments with built in functions.
     For instance, the following setup allows different activities at the
     day, month, and year level:
 
-    class DayHandler:
-        def index(self, year, month, day):
-            #Do something with this day; probably list entries
+    .. code-block:: python
 
-        def delete(self, year, month, day):
-            #Delete all entries for this day
+        class DayHandler:
+            def index(self, year, month, day):
+                #Do something with this day; probably list entries
 
-    @cherrypy.popargs('day', handler=DayHandler())
-    class MonthHandler:
-        def index(self, year, month):
-            #Do something with this month; probably list entries
+            def delete(self, year, month, day):
+                #Delete all entries for this day
 
-        def delete(self, year, month):
-            #Delete all entries for this month
+        @cherrypy.popargs('day', handler=DayHandler())
+        class MonthHandler:
+            def index(self, year, month):
+                #Do something with this month; probably list entries
 
-    @cherrypy.popargs('month', handler=MonthHandler())
-    class YearHandler:
-        def index(self, year):
-            #Do something with this year
+            def delete(self, year, month):
+                #Delete all entries for this month
 
-        #...
+        @cherrypy.popargs('month', handler=MonthHandler())
+        class YearHandler:
+            def index(self, year):
+                #Do something with this year
 
-    @cherrypy.popargs('year', handler=YearHandler())
-    class Root:
-        def index(self):
             #...
+
+        @cherrypy.popargs('year', handler=YearHandler())
+        class Root:
+            def index(self):
+                #...
 
     """
     # Since keyword arg comes after *args, we have to process it ourselves

--- a/cherrypy/lib/cptools.py
+++ b/cherrypy/lib/cptools.py
@@ -409,7 +409,7 @@ def session_auth(**kwargs):
     Any attribute of the SessionAuth class may be overridden
     via a keyword arg to this function:
 
-    """ + '\n'.join(
+    """ + '\n    '.join(
         '{!s}: {!s}'.format(k, type(getattr(SessionAuth, k)).__name__)
         for k in dir(SessionAuth)
         if not k.startswith('__')

--- a/cherrypy/test/modwsgi.py
+++ b/cherrypy/test/modwsgi.py
@@ -9,18 +9,18 @@ create a symlink to them if needed.
 KNOWN BUGS
 ==========
 
-##1. Apache processes Range headers automatically; CherryPy's truncated
-##    output is then truncated again by Apache. See test_core.testRanges.
-##    This was worked around in http://www.cherrypy.org/changeset/1319.
+1. Apache processes Range headers automatically; CherryPy's truncated
+    output is then truncated again by Apache. See test_core.testRanges.
+    This was worked around in http://www.cherrypy.org/changeset/1319.
 2. Apache does not allow custom HTTP methods like CONNECT as per the spec.
     See test_core.testHTTPMethods.
 3. Max request header and body settings do not work with Apache.
-##4. Apache replaces status "reason phrases" automatically. For example,
-##    CherryPy may set "304 Not modified" but Apache will write out
-##    "304 Not Modified" (capital "M").
-##5. Apache does not allow custom error codes as per the spec.
-##6. Apache (or perhaps modpython, or modpython_gateway) unquotes %xx in the
-##    Request-URI too early.
+4. Apache replaces status "reason phrases" automatically. For example,
+    CherryPy may set "304 Not modified" but Apache will write out
+    "304 Not Modified" (capital "M").
+5. Apache does not allow custom error codes as per the spec.
+6. Apache (or perhaps modpython, or modpython_gateway) unquotes %xx in the
+    Request-URI too early.
 7. mod_wsgi will not read request bodies which use the "chunked"
     transfer-coding (it passes REQUEST_CHUNKED_ERROR to ap_setup_client_block
     instead of REQUEST_CHUNKED_DECHUNK, see Apache2's http_protocol.c and

--- a/cherrypy/test/test_http.py
+++ b/cherrypy/test/test_http.py
@@ -185,12 +185,14 @@ class HTTPTests(helper.CPWebCase):
         self.assertBody(', '.join(parts))
 
     def test_post_filename_with_special_characters(self):
-        '''Testing that we can handle filenames with special characters. This
-        was reported as a bug in:
-           https://github.com/cherrypy/cherrypy/issues/1146/
-           https://github.com/cherrypy/cherrypy/issues/1397/
-           https://github.com/cherrypy/cherrypy/issues/1694/
-        '''
+        """Testing that we can handle filenames with special characters.
+
+        This was reported as a bug in:
+
+        * https://github.com/cherrypy/cherrypy/issues/1146/
+        * https://github.com/cherrypy/cherrypy/issues/1397/
+        * https://github.com/cherrypy/cherrypy/issues/1694/
+        """
         # We'll upload a bunch of files with differing names.
         fnames = [
             'boop.csv', 'foo, bar.csv', 'bar, xxxx.csv', 'file"name.csv',

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -579,8 +579,8 @@ it is distributed and a good choice if you want to
 share sessions outside of the process running CherryPy.
 
 Requires that the Python
-`memcached <https://pypi.org/project/memcached>`__
-package is installed, which may be indicated by installing
+`memcached package <https://pypi.org/project/memcached>`_
+is installed, which may be indicated by installing
 ``cherrypy[memcached_session]``.
 
 .. code-block:: ini


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [x] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other


**What is the related issue number (starting with `#`)**

* #1797 (original issue)
* #1812 (first PR that has ugly git history - CLOSED)
* #1822 (second PR that addressed docs, but had ugly git history - CLOSED)
* #1819 (PR from @jay1723 which I believe can be closed, as this PR covers the same warnings)

**What is the current behavior?** (You can also link to an open issue here)

Docs build with sphinx warnings

```
../CHANGES (links).rst:140: WARNING: Unexpected indentation.
/home/travis/build/cherrypy/cherrypy/cherrypy/test/modwsgi.py:docstring of cherrypy.test.modwsgi:16: WARNING: Unexpected indentation.
/home/travis/build/cherrypy/cherrypy/cherrypy/test/modwsgi.py:docstring of cherrypy.test.modwsgi:17: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/travis/build/cherrypy/cherrypy/cherrypy/test/modwsgi.py:docstring of cherrypy.test.modwsgi:25: WARNING: Unexpected indentation.
/home/travis/build/cherrypy/cherrypy/cherrypy/test/modwsgi.py:docstring of cherrypy.test.modwsgi:28: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/travis/build/cherrypy/cherrypy/cherrypy/test/test_http.py:docstring of cherrypy.test.test_http.HTTPTests.test_post_filename_with_special_characters:3: WARNING: Unexpected indentation.
/home/travis/build/cherrypy/cherrypy/docs/basics.rst:4: WARNING: Duplicate explicit target name: "memcached".
```

**What is the new behavior (if this is a feature change)?**

Warnings above are addressed and resolved

**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
