### PR TITLE
Rely on jaraco.collections for CaseInsensitiveDict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v18.5.0
+-------
+
+* :pr:`1826`: Rely on
+  `jaraco.collections <https://pypi.org/project/jaraco.collections>`_
+  for its case-insensitive dictionary support.
+
 v18.4.0
 -------
 

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -17,6 +17,8 @@ from email.header import decode_header
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import unquote_plus
 
+import jaraco.collections
+
 import cherrypy
 from cherrypy._cpcompat import ntob, ntou
 
@@ -385,68 +387,7 @@ def parse_query_string(query_string, keep_blank_values=True, encoding='utf-8'):
     return pm
 
 
-####
-# Inlined from jaraco.collections 1.5.2
-# Ref #1673
-class KeyTransformingDict(dict):
-    """
-    A dict subclass that transforms the keys before they're used.
-    Subclasses may override the default transform_key to customize behavior.
-    """
-    @staticmethod
-    def transform_key(key):
-        return key
-
-    def __init__(self, *args, **kargs):
-        super(KeyTransformingDict, self).__init__()
-        # build a dictionary using the default constructs
-        d = dict(*args, **kargs)
-        # build this dictionary using transformed keys.
-        for item in d.items():
-            self.__setitem__(*item)
-
-    def __setitem__(self, key, val):
-        key = self.transform_key(key)
-        super(KeyTransformingDict, self).__setitem__(key, val)
-
-    def __getitem__(self, key):
-        key = self.transform_key(key)
-        return super(KeyTransformingDict, self).__getitem__(key)
-
-    def __contains__(self, key):
-        key = self.transform_key(key)
-        return super(KeyTransformingDict, self).__contains__(key)
-
-    def __delitem__(self, key):
-        key = self.transform_key(key)
-        return super(KeyTransformingDict, self).__delitem__(key)
-
-    def get(self, key, *args, **kwargs):
-        key = self.transform_key(key)
-        return super(KeyTransformingDict, self).get(key, *args, **kwargs)
-
-    def setdefault(self, key, *args, **kwargs):
-        key = self.transform_key(key)
-        return super(KeyTransformingDict, self).setdefault(
-            key, *args, **kwargs)
-
-    def pop(self, key, *args, **kwargs):
-        key = self.transform_key(key)
-        return super(KeyTransformingDict, self).pop(key, *args, **kwargs)
-
-    def matching_key_for(self, key):
-        """
-        Given a key, return the actual key stored in self that matches.
-        Raise KeyError if the key isn't found.
-        """
-        try:
-            return next(e_key for e_key in self.keys() if e_key == key)
-        except StopIteration:
-            raise KeyError(key)
-####
-
-
-class CaseInsensitiveDict(KeyTransformingDict):
+class CaseInsensitiveDict(jaraco.collections.KeyTransformingDict):
 
     """A case-insensitive dict subclass.
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ params = dict(
         'portend>=2.1.1',
         'more_itertools',
         'zc.lockfile',
+        'jaraco.collections',
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
Replaced inlined code with upstream dependency now that #1673 has been long fixed.