### PR TITLE
Potential fix for HeaderMap issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v18.4.1
+-------
+
+* :issue:`1827`: Fixed issue where bytes values in a ``HeaderMap``
+  would be converted to strings.
+
 v18.4.0
 -------
 

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -456,7 +456,7 @@ class CaseInsensitiveDict(KeyTransformingDict):
     @staticmethod
     def transform_key(key):
         if key is None:
-            # TODO: why?
+            # TODO(#1830): why?
             return 'None'
         return key.title()
 

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -450,12 +450,15 @@ class CaseInsensitiveDict(KeyTransformingDict):
 
     """A case-insensitive dict subclass.
 
-    Each key is changed on entry to str(key).title().
+    Each key is changed on entry to title case.
     """
 
     @staticmethod
     def transform_key(key):
-        return str(key).title()
+        if key is None:
+            # TODO: why?
+            return 'None'
+        return key.title()
 
 
 #   TEXT = <any OCTET except CTLs, but including LWS>
@@ -494,9 +497,7 @@ class HeaderMap(CaseInsensitiveDict):
 
     def elements(self, key):
         """Return a sorted list of HeaderElements for the given header."""
-        key = str(key).title()
-        value = self.get(key)
-        return header_elements(key, value)
+        return header_elements(self.transform_key(key), self.get(key))
 
     def values(self, key):
         """Return a sorted list of HeaderElement.value for the given header."""


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

#1827

# Discussion

I'm not sure this fix is the right one. I did not attempt to resolve what values _should_ be allowed for keys to a `HeaderMap`, only to address the issue that _if_ they're bytes, they're treated duck-like strings. Perhaps the right thing to do is just crash on non-text keys and require the callers to decode any bytes values.

I've called out `None` values as a special case, as tests fail without them. Perhaps that should be an error too, but for now, because the tests demand it, they're supported.