### PR TITLE
Add bindep file to install system packages

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,3 @@
+gcc                     [platform:dpkg]
+libenchant1c2a          [platform:dpkg]
+python3-dev             [platform:dpkg]


### PR DESCRIPTION
Some tests require installing extra system packages.
To handle this we create bindep file that gets consumed with [bindep]
during CI jobs.

[bindep]: https://opendev.org/opendev/bindep

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
