### PR TITLE
Fix serving files with diacritics in name under their original name

### DIFF
--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -35,12 +35,12 @@ def _make_content_disposition(disposition, file_name):
     This function implements the recommendations of :rfc:`6266#appendix-D`.
     See this and related answers: https://stackoverflow.com/a/8996249/2173868.
     """
-    # As normalization algorithm for `unicodedata` is used composed form (NFC and NFKC)
-    # with compatibility equivalence criteria (NFK), so "NFKC" is the one.
-    # It first applies the compatibility decomposition, followed by the canonical
-    # composition. Should be displayed in the same manner, should be treated in
-    # the same way by applications such as alphabetizing names or searching,
-    # and may be substituted for each other.
+    # As normalization algorithm for `unicodedata` is used composed form (NFC
+    # and NFKC) with compatibility equivalence criteria (NFK), so "NFKC" is the
+    # one. It first applies the compatibility decomposition, followed by the
+    # canonical composition. Should be displayed in the same manner, should be
+    # treated in the same way by applications such as alphabetizing names or
+    # searching, and may be substituted for each other.
     # See: https://en.wikipedia.org/wiki/Unicode_equivalence.
     ascii_name = (
         unicodedata.normalize('NFKC', file_name).

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -39,10 +39,10 @@ def _make_content_disposition(disposition, file_name):
         unicodedata.normalize('NFKD', file_name).
         encode('ascii', errors='ignore').decode()
     )
-    header = u'{}; filename="{}"'.format(disposition, ascii_name)
+    header = '{}; filename="{}"'.format(disposition, ascii_name)
     if ascii_name != file_name:
         quoted_name = urllib.parse.quote(file_name)
-        header += u'; filename*=UTF-8\'\'{}'.format(quoted_name)
+        header += '; filename*=UTF-8\'\'{}'.format(quoted_name)
     return header
 
 

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -30,9 +30,10 @@ _setup_mimetypes()
 
 
 def _utf8_content_disposition(disposition, file_name):
-    """Create HTTP header for downloading a file with UTF-8 filename.
-    See this and related answers:
-    https://stackoverflow.com/a/8996249/2173868
+    """Create HTTP header for downloading a file with a UTF-8 filename.
+
+    This function implements the recommendations of :rfc:`6266#appendix-D`.
+    See this and related answers: https://stackoverflow.com/a/8996249/2173868.
     """
     ascii_name = (
         unicodedata.normalize('NFKD', file_name).

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -29,7 +29,7 @@ def _setup_mimetypes():
 _setup_mimetypes()
 
 
-def _utf8_content_disposition(disposition, file_name):
+def _make_content_disposition(disposition, file_name):
     """Create HTTP header for downloading a file with a UTF-8 filename.
 
     This function implements the recommendations of :rfc:`6266#appendix-D`.
@@ -110,7 +110,7 @@ def serve_file(path, content_type=None, disposition=None, name=None,
     if disposition is not None:
         if name is None:
             name = os.path.basename(path)
-        cd = _utf8_content_disposition(disposition, name)
+        cd = _make_content_disposition(disposition, name)
         response.headers['Content-Disposition'] = cd
     if debug:
         cherrypy.log('Content-Disposition: %r' % cd, 'TOOLS.STATIC')
@@ -168,7 +168,7 @@ def serve_fileobj(fileobj, content_type=None, disposition=None, name=None,
         if name is None:
             cd = disposition
         else:
-            cd = _utf8_content_disposition(disposition, name)
+            cd = _make_content_disposition(disposition, name)
         response.headers['Content-Disposition'] = cd
     if debug:
         cherrypy.log('Content-Disposition: %r' % cd, 'TOOLS.STATIC')

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -39,9 +39,10 @@ def _make_content_disposition(disposition, file_name):
         unicodedata.normalize('NFKD', file_name).
         encode('ascii', errors='ignore').decode()
     )
-    quoted_name = urllib.parse.quote(file_name)
     header = u'{}; filename="{}"'.format(disposition, ascii_name)
-    header += u'; filename*=UTF-8\'\'{}'.format(quoted_name)
+    if ascii_name != file_name:
+        quoted_name = urllib.parse.quote(file_name)
+        header += u'; filename*=UTF-8\'\'{}'.format(quoted_name)
     return header
 
 

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -28,22 +28,6 @@ def _setup_mimetypes():
 _setup_mimetypes()
 
 
-def _utf8_content_disposition(disposition, file_name):
-    """Create HTTP header for downloading a file with UTF-8 filename.
-
-    See this and related answers:
-    https://stackoverflow.com/a/8996249/2173868
-    """
-    ascii_name = (
-        unicodedata.normalize('NFKD', file_name).
-        encode('ascii', errors='ignore').decode()
-    )
-    quoted_name = urllib.parse.quote(file_name)
-    header = u'{}; filename="{}"'.format(disposition, ascii_name)
-    header += u'; filename*=UTF-8\'\'{}'.format(quoted_name)
-    return header
-
-
 def serve_file(path, content_type=None, disposition=None, name=None,
                debug=False):
     """Set status, headers, and body in order to serve the given path.
@@ -53,10 +37,9 @@ def serve_file(path, content_type=None, disposition=None, name=None,
     of the 'path' argument.
 
     If disposition is not None, the Content-Disposition header will be set
-    to "<disposition>; filename=<name>; filename*=utf-8''<name>"
-    as described in RFC6266 (https://tools.ietf.org/html/rfc6266#appendix-D).
-    If name is None, it will be set to the basename of path.
-    If disposition is None, no Content-Disposition header will be written.
+    to "<disposition>; filename=<name>". If name is None, it will be set
+    to the basename of path. If disposition is None, no Content-Disposition
+    header will be written.
     """
     response = cherrypy.serving.response
 
@@ -109,7 +92,7 @@ def serve_file(path, content_type=None, disposition=None, name=None,
     if disposition is not None:
         if name is None:
             name = os.path.basename(path)
-        cd = _utf8_content_disposition(disposition, name)
+        cd = '%s; filename="%s"' % (disposition, name)
         response.headers['Content-Disposition'] = cd
     if debug:
         cherrypy.log('Content-Disposition: %r' % cd, 'TOOLS.STATIC')
@@ -128,10 +111,9 @@ def serve_fileobj(fileobj, content_type=None, disposition=None, name=None,
     The Content-Type header will be set to the content_type arg, if provided.
 
     If disposition is not None, the Content-Disposition header will be set
-    to "<disposition>; filename=<name>; filename*=utf-8''<name>"
-    as described in RFC6266 (https://tools.ietf.org/html/rfc6266#appendix-D).
-    If name is None, 'filename' will not be set.
-    If disposition is None, no Content-Disposition header will be written.
+    to "<disposition>; filename=<name>". If name is None, 'filename' will
+    not be set. If disposition is None, no Content-Disposition header will
+    be written.
 
     CAUTION: If the request contains a 'Range' header, one or more seek()s will
     be performed on the file object.  This may cause undesired behavior if
@@ -167,7 +149,7 @@ def serve_fileobj(fileobj, content_type=None, disposition=None, name=None,
         if name is None:
             cd = disposition
         else:
-            cd = _utf8_content_disposition(disposition, name)
+            cd = '%s; filename="%s"' % (disposition, name)
         response.headers['Content-Disposition'] = cd
     if debug:
         cherrypy.log('Content-Disposition: %r' % cd, 'TOOLS.STATIC')

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -34,15 +34,14 @@ def _make_content_disposition(disposition, file_name):
 
     This function implements the recommendations of :rfc:`6266#appendix-D`.
     See this and related answers: https://stackoverflow.com/a/8996249/2173868.
-
-    As normalization algorithm for `unicodedata` is used composed form (NFC and NKFC)
-    with compatibility equivalence criteria (NFK), so "NKFC" is the one.
-    It first applies the compatibility decomposition, followed by the canonical
-    composition. Should be displayed in the same manner, should be treated in
-    the same way by applications such as alphabetizing names or searching,
-    and may be substituted for each other.
-    See: https://en.wikipedia.org/wiki/Unicode_equivalence.
     """
+    # As normalization algorithm for `unicodedata` is used composed form (NFC and NKFC)
+    # with compatibility equivalence criteria (NFK), so "NKFC" is the one.
+    # It first applies the compatibility decomposition, followed by the canonical
+    # composition. Should be displayed in the same manner, should be treated in
+    # the same way by applications such as alphabetizing names or searching,
+    # and may be substituted for each other.
+    # See: https://en.wikipedia.org/wiki/Unicode_equivalence.
     ascii_name = (
         unicodedata.normalize('NKFC', file_name).
         encode('ascii', errors='ignore').decode()

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -35,15 +35,15 @@ def _make_content_disposition(disposition, file_name):
     This function implements the recommendations of :rfc:`6266#appendix-D`.
     See this and related answers: https://stackoverflow.com/a/8996249/2173868.
     """
-    # As normalization algorithm for `unicodedata` is used composed form (NFC and NKFC)
-    # with compatibility equivalence criteria (NFK), so "NKFC" is the one.
+    # As normalization algorithm for `unicodedata` is used composed form (NFC and NFKC)
+    # with compatibility equivalence criteria (NFK), so "NFKC" is the one.
     # It first applies the compatibility decomposition, followed by the canonical
     # composition. Should be displayed in the same manner, should be treated in
     # the same way by applications such as alphabetizing names or searching,
     # and may be substituted for each other.
     # See: https://en.wikipedia.org/wiki/Unicode_equivalence.
     ascii_name = (
-        unicodedata.normalize('NKFC', file_name).
+        unicodedata.normalize('NFKC', file_name).
         encode('ascii', errors='ignore').decode()
     )
     header = '{}; filename="{}"'.format(disposition, ascii_name)

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -34,9 +34,17 @@ def _make_content_disposition(disposition, file_name):
 
     This function implements the recommendations of :rfc:`6266#appendix-D`.
     See this and related answers: https://stackoverflow.com/a/8996249/2173868.
+
+    As normalization algorithm for `unicodedata` is used composed form (NFC and NKFC)
+    with compatibility equivalence criteria (NFK), so "NKFC" is the one.
+    It first applies the compatibility decomposition, followed by the canonical
+    composition. Should be displayed in the same manner, should be treated in
+    the same way by applications such as alphabetizing names or searching,
+    and may be substituted for each other.
+    See: https://en.wikipedia.org/wiki/Unicode_equivalence.
     """
     ascii_name = (
-        unicodedata.normalize('NFKD', file_name).
+        unicodedata.normalize('NKFC', file_name).
         encode('ascii', errors='ignore').decode()
     )
     header = '{}; filename="{}"'.format(disposition, ascii_name)

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -6,6 +6,7 @@ import re
 import stat
 import mimetypes
 import urllib.parse
+import unicodedata
 
 from email.generator import _make_boundary as make_boundary
 from io import UnsupportedOperation
@@ -28,6 +29,21 @@ def _setup_mimetypes():
 _setup_mimetypes()
 
 
+def _utf8_content_disposition(disposition, file_name):
+    """Create HTTP header for downloading a file with UTF-8 filename.
+    See this and related answers:
+    https://stackoverflow.com/a/8996249/2173868
+    """
+    ascii_name = (
+        unicodedata.normalize('NFKD', file_name).
+        encode('ascii', errors='ignore').decode()
+    )
+    quoted_name = urllib.parse.quote(file_name)
+    header = u'{}; filename="{}"'.format(disposition, ascii_name)
+    header += u'; filename*=UTF-8\'\'{}'.format(quoted_name)
+    return header
+
+
 def serve_file(path, content_type=None, disposition=None, name=None,
                debug=False):
     """Set status, headers, and body in order to serve the given path.
@@ -37,9 +53,10 @@ def serve_file(path, content_type=None, disposition=None, name=None,
     of the 'path' argument.
 
     If disposition is not None, the Content-Disposition header will be set
-    to "<disposition>; filename=<name>". If name is None, it will be set
-    to the basename of path. If disposition is None, no Content-Disposition
-    header will be written.
+    to "<disposition>; filename=<name>; filename*=utf-8''<name>"
+    as described in RFC6266 (https://tools.ietf.org/html/rfc6266#appendix-D).
+    If name is None, it will be set to the basename of path.
+    If disposition is None, no Content-Disposition header will be written.
     """
     response = cherrypy.serving.response
 
@@ -92,7 +109,7 @@ def serve_file(path, content_type=None, disposition=None, name=None,
     if disposition is not None:
         if name is None:
             name = os.path.basename(path)
-        cd = '%s; filename="%s"' % (disposition, name)
+        cd = _utf8_content_disposition(disposition, name)
         response.headers['Content-Disposition'] = cd
     if debug:
         cherrypy.log('Content-Disposition: %r' % cd, 'TOOLS.STATIC')
@@ -111,9 +128,10 @@ def serve_fileobj(fileobj, content_type=None, disposition=None, name=None,
     The Content-Type header will be set to the content_type arg, if provided.
 
     If disposition is not None, the Content-Disposition header will be set
-    to "<disposition>; filename=<name>". If name is None, 'filename' will
-    not be set. If disposition is None, no Content-Disposition header will
-    be written.
+    to "<disposition>; filename=<name>; filename*=utf-8''<name>"
+    as described in RFC6266 (https://tools.ietf.org/html/rfc6266#appendix-D).
+    If name is None, 'filename' will not be set.
+    If disposition is None, no Content-Disposition header will be written.
 
     CAUTION: If the request contains a 'Range' header, one or more seek()s will
     be performed on the file object.  This may cause undesired behavior if
@@ -149,7 +167,7 @@ def serve_fileobj(fileobj, content_type=None, disposition=None, name=None,
         if name is None:
             cd = disposition
         else:
-            cd = '%s; filename="%s"' % (disposition, name)
+            cd = _utf8_content_disposition(disposition, name)
         response.headers['Content-Disposition'] = cd
     if debug:
         cherrypy.log('Content-Disposition: %r' % cd, 'TOOLS.STATIC')

--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -54,7 +54,7 @@ def serve_file(path, content_type=None, disposition=None, name=None,
 
     If disposition is not None, the Content-Disposition header will be set
     to "<disposition>; filename=<name>; filename*=utf-8''<name>"
-    as described in RFC6266 (https://tools.ietf.org/html/rfc6266#appendix-D).
+    as described in :rfc:`6266#appendix-D`.
     If name is None, it will be set to the basename of path.
     If disposition is None, no Content-Disposition header will be written.
     """
@@ -129,7 +129,7 @@ def serve_fileobj(fileobj, content_type=None, disposition=None, name=None,
 
     If disposition is not None, the Content-Disposition header will be set
     to "<disposition>; filename=<name>; filename*=utf-8''<name>"
-    as described in RFC6266 (https://tools.ietf.org/html/rfc6266#appendix-D).
+    as described in :rfc:`6266#appendix-D`.
     If name is None, 'filename' will not be set.
     If disposition is None, no Content-Disposition header will be written.
 

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -99,9 +99,8 @@ class StaticTest(helper.CPWebCase):
 
             @cherrypy.expose
             def serve_file_utf8_filename(self):
-                file_path = os.path.join(curdir, 'style.css')
                 return static.serve_file(
-                    file_path,
+                    __file__,
                     disposition='attachment',
                     name='has_utf-8_character_☃.html')
 

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -211,15 +211,18 @@ class StaticTest(helper.CPWebCase):
         # Check a filename with utf-8 characters in it
         ascii_fn = 'has_utf-8_character_.html'
         url_quote_fn = 'has_utf-8_character_%E2%98%83.html'  # %E2%98%83 == ☃
-        cd = '''attachment; filename="%s"; filename*=UTF-8\'\'%s'''
+        expected_content_disposition = (
+            'attachment; filename="{!s}"; filename*=UTF-8\'\'{!s}'.
+            format(ascii_fn, url_quote_fn)
+        )
 
         self.getPage('/serve_file_utf8_filename')
         self.assertStatus('200 OK')
-        self.assertHeader('Content-Disposition', cd % (ascii_fn, url_quote_fn))
+        self.assertHeader('Content-Disposition', expected_content_disposition)
 
         self.getPage('/serve_fileobj_utf8_filename')
         self.assertStatus('200 OK')
-        self.assertHeader('Content-Disposition', cd % (ascii_fn, url_quote_fn))
+        self.assertHeader('Content-Disposition', expected_content_disposition)
 
     @pytest.mark.skipif(platform.system() != 'Windows', reason='Windows only')
     def test_static_longpath(self):

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -107,7 +107,7 @@ class StaticTest(helper.CPWebCase):
             @cherrypy.expose
             def serve_fileobj_utf8_filename(self):
                 return static.serve_fileobj(
-                    io.BytesIO(b'☃\nfie\nfo\nfum'),
+                    io.BytesIO('☃\nfie\nfo\nfum'.encode('utf-8')),
                     disposition='attachment',
                     name='has_utf-8_character_☃.html')
 

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -210,7 +210,7 @@ class StaticTest(helper.CPWebCase):
 
         # Check a filename with utf-8 characters in it
         ascii_fn = 'has_utf-8_character_.html'
-        url_quote_fn = 'has_utf-8_character_%E2%98%83.html'
+        url_quote_fn = 'has_utf-8_character_%E2%98%83.html'  # %E2%98%83 == ☃
         cd = '''attachment; filename="%s"; filename*=UTF-8\'\'%s'''
 
         self.getPage('/serve_file_utf8_filename')

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -107,9 +107,8 @@ class StaticTest(helper.CPWebCase):
 
             @cherrypy.expose
             def serve_fileobj_utf8_filename(self):
-                f = open(os.path.join(curdir, 'style.css'), 'rb')
                 return static.serve_fileobj(
-                    f,
+                    io.BytesIO(b'☃\nfie\nfo\nfum'),
                     disposition='attachment',
                     name='has_utf-8_character_☃.html')
 

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -97,22 +97,6 @@ class StaticTest(helper.CPWebCase):
                 f = io.BytesIO(b'Fee\nfie\nfo\nfum')
                 return static.serve_fileobj(f, content_type='text/plain')
 
-            @cherrypy.expose
-            def serve_file_utf8_filename(self):
-                file_path = os.path.join(curdir, 'style.css')
-                return static.serve_file(
-                    file_path,
-                    disposition='attachment',
-                    name='has_utf-8_character_☃.html')
-
-            @cherrypy.expose
-            def serve_fileobj_utf8_filename(self):
-                f = open(os.path.join(curdir, 'style.css'), 'rb')
-                return static.serve_fileobj(
-                    f,
-                    disposition='attachment',
-                    name='has_utf-8_character_☃.html')
-
         class Static:
 
             @cherrypy.expose
@@ -208,19 +192,6 @@ class StaticTest(helper.CPWebCase):
         #   into \r\n on Windows when extracting the CherryPy tarball so
         #   we just check the content
         self.assertMatchesBody('^Dummy stylesheet')
-
-        # Check a filename with utf-8 characters in it
-        ascii_fn = 'has_utf-8_character_.html'
-        url_quote_fn = u'has_utf-8_character_%E2%98%83.html'
-        cd = '''attachment; filename="%s"; filename*=UTF-8\'\'%s'''
-
-        self.getPage('/serve_file_utf8_filename')
-        self.assertStatus('200 OK')
-        self.assertHeader('Content-Disposition', cd % (ascii_fn, url_quote_fn))
-
-        self.getPage('/serve_fileobj_utf8_filename')
-        self.assertStatus('200 OK')
-        self.assertHeader('Content-Disposition', cd % (ascii_fn, url_quote_fn))
 
     @pytest.mark.skipif(platform.system() != 'Windows', reason='Windows only')
     def test_static_longpath(self):

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -97,6 +97,22 @@ class StaticTest(helper.CPWebCase):
                 f = io.BytesIO(b'Fee\nfie\nfo\nfum')
                 return static.serve_fileobj(f, content_type='text/plain')
 
+            @cherrypy.expose
+            def serve_file_utf8_filename(self):
+                file_path = os.path.join(curdir, 'style.css')
+                return static.serve_file(
+                    file_path,
+                    disposition='attachment',
+                    name='has_utf-8_character_☃.html')
+
+            @cherrypy.expose
+            def serve_fileobj_utf8_filename(self):
+                f = open(os.path.join(curdir, 'style.css'), 'rb')
+                return static.serve_fileobj(
+                    f,
+                    disposition='attachment',
+                    name='has_utf-8_character_☃.html')
+
         class Static:
 
             @cherrypy.expose
@@ -192,6 +208,19 @@ class StaticTest(helper.CPWebCase):
         #   into \r\n on Windows when extracting the CherryPy tarball so
         #   we just check the content
         self.assertMatchesBody('^Dummy stylesheet')
+
+        # Check a filename with utf-8 characters in it
+        ascii_fn = 'has_utf-8_character_.html'
+        url_quote_fn = u'has_utf-8_character_%E2%98%83.html'
+        cd = '''attachment; filename="%s"; filename*=UTF-8\'\'%s'''
+
+        self.getPage('/serve_file_utf8_filename')
+        self.assertStatus('200 OK')
+        self.assertHeader('Content-Disposition', cd % (ascii_fn, url_quote_fn))
+
+        self.getPage('/serve_fileobj_utf8_filename')
+        self.assertStatus('200 OK')
+        self.assertHeader('Content-Disposition', cd % (ascii_fn, url_quote_fn))
 
     @pytest.mark.skipif(platform.system() != 'Windows', reason='Windows only')
     def test_static_longpath(self):


### PR DESCRIPTION
This implements adding extra ``filename*`` parameter in Content-disposition
header when serving content with non-ASCII filenames. As per RFC 6266
recommendations in the Appendix D.

Refs:
* https://stackoverflow.com/a/8996249/2173868
* https://tools.ietf.org/html/rfc6266#appendix-D

Fixes #1776

**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
Fixes #1776


**What is the current behavior?** (You can also link to an open issue here)
#1776


**What is the new behavior (if this is a feature change)?**



**Other information**:
Previous pull request #1777 was closed due hard reset of the fork base to current version of cherrypy.

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit