### PR TITLE
Fix compression level in meta header in gzip tool

### DIFF
--- a/cherrypy/lib/encoding.py
+++ b/cherrypy/lib/encoding.py
@@ -9,6 +9,10 @@ from cherrypy.lib import is_closable_iterator
 from cherrypy.lib import set_vary_header
 
 
+_COMPRESSION_LEVEL_FAST = 1
+_COMPRESSION_LEVEL_BEST = 9
+
+
 def decode(encoding=None, default_encoding='utf-8'):
     """Replace or extend the list of charsets used to decode a request entity.
 
@@ -285,13 +289,29 @@ def compress(body, compress_level):
     """Compress 'body' at the given compress_level."""
     import zlib
 
-    # See http://www.gzip.org/zlib/rfc-gzip.html
+    # See https://tools.ietf.org/html/rfc1952
     yield b'\x1f\x8b'       # ID1 and ID2: gzip marker
     yield b'\x08'           # CM: compression method
     yield b'\x00'           # FLG: none set
     # MTIME: 4 bytes
     yield struct.pack('<L', int(time.time()) & int('FFFFFFFF', 16))
-    yield b'\x02'           # XFL: max compression, slowest algo
+
+    # RFC 1952, section 2.3.1:
+    #
+    # XFL (eXtra FLags)
+    #    These flags are available for use by specific compression
+    #    methods.  The "deflate" method (CM = 8) sets these flags as
+    #    follows:
+    #
+    #       XFL = 2 - compressor used maximum compression,
+    #                 slowest algorithm
+    #       XFL = 4 - compressor used fastest algorithm
+    if compress_level == _COMPRESSION_LEVEL_BEST:
+        yield b'\x02'       # XFL: max compression, slowest algo
+    elif compress_level == _COMPRESSION_LEVEL_FAST:
+        yield b'\x04'       # XFL: min compression, fastest algo
+    else:
+        yield b'\x00'       # XFL: compression unset/tradeoff
     yield b'\xff'           # OS: unknown
 
     crc = zlib.crc32(b'')

--- a/cherrypy/test/test_tools.py
+++ b/cherrypy/test/test_tools.py
@@ -15,6 +15,16 @@ from cherrypy._cpcompat import ntou
 from cherrypy.test import helper, _test_decorators
 
 
+*PY_VER_MINOR, _ = PY_VER_PATCH = sys.version_info[:3]
+# Refs:
+# bugs.python.org/issue39389
+# docs.python.org/3.7/whatsnew/changelog.html#python-3-7-7-release-candidate-1
+# docs.python.org/3.8/whatsnew/changelog.html#python-3-8-2-release-candidate-1
+HAS_GZIP_COMPRESSION_HEADER_FIXED = PY_VER_PATCH >= (3, 8, 2) or (
+    PY_VER_MINOR == (3, 7) and PY_VER_PATCH >= (3, 7, 7)
+)
+
+
 timeout = 0.2
 europoundUnicode = ntou('\x80\xa3')
 
@@ -357,6 +367,13 @@ class ToolTests(helper.CPWebCase):
                          ('Accept-Charset', 'ISO-8859-1,utf-8;q=0.7,*;q=0.7')])
         self.assertInBody(zbuf.getvalue()[:3])
 
+        if not HAS_GZIP_COMPRESSION_HEADER_FIXED:
+            # NOTE: CherryPy adopts a fix from the CPython bug 39389
+            # NOTE: introducing a variable compression XFL flag that
+            # NOTE: was hardcoded to "best compression" before. And so
+            # NOTE: we can only test it on CPython versions that also
+            # NOTE: implement this fix.
+            return
         zbuf = io.BytesIO()
         zfile = gzip.GzipFile(mode='wb', fileobj=zbuf, compresslevel=6)
         zfile.write(expectedResult)


### PR DESCRIPTION
This change fixes XLF flag of a gzip header in the gzip tool according to the actual compression requested.

It ports a similar solution implemented in CPython 3.7.7+, 3.8.2+ and 3.9.0+


**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

Fixes #1849

**What is the current behavior?** (You can also link to an open issue here)

Gzip tool compression implementation hardcodes XLF flag of a gzip header was hardcoded to say "best compression".

**What is the new behavior (if this is a feature change)?**



**Other information**:

* https://bugs.python.org/issue39389

* https://github.com/python/cpython/pull/18077
* https://github.com/python/cpython/pull/18100
* https://github.com/python/cpython/pull/18101

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
