### PR TITLE
Remove `backports.unittest_mock` from testing deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,6 @@ params = dict(
             'pytest>=5.3.5,<6.1.0',
             'pytest-cov',
             'pytest-sugar',
-            'backports.unittest_mock',
             'path.py',
             'requests_toolbelt',
             'pytest-services>=2',


### PR DESCRIPTION
Line 112, `python_requires='>=3.5',` means that this backport is no longer required.

**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
