### PR TITLE
CircleCI: Reenable macOS testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
         wait
     - run: pyenv global 3.7.0 3.6.4 3.5.4 pypy3.5-6.0.0
 
-    - run: pip install tox tox-pyenv
+    - run: python3 -m pip install --upgrade pip wheel
+    - run: python3 -m pip install tox tox-pyenv
     - checkout
     - run: tox -e py35,py36,py37,pypy3 -- -p no:sugar
     - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   macos-build:
     macos:
-      xcode: "9.3.1"
+      xcode: "12.2.0"
 
     steps:
     - run: brew install pyenv readline xz


### PR DESCRIPTION
A minimal subset of #1877

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**

```
Job macos-build (1090): failed
Duration / Finished: 4s / 3m ago
Build-agent version 1.0.45118-e4a604da (2020-11-13T12:37:04+0000)
Creating a dedicated VM with xcode:9.3.1 image
failed to create host: Image xcode:9.3.1 is not supported
```

**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
