### PR TITLE
Remove pytest.mark.xfail on test_queue_full

### DIFF
--- a/cherrypy/test/test_conn.py
+++ b/cherrypy/test/test_conn.py
@@ -7,8 +7,6 @@ import time
 import urllib.parse
 from http.client import BadStatusLine, HTTPConnection, NotConnected
 
-import pytest
-
 from cheroot.test import webtest
 
 import cherrypy

--- a/cherrypy/test/test_conn.py
+++ b/cherrypy/test/test_conn.py
@@ -778,7 +778,6 @@ socket_reset_errors += [
 class LimitedRequestQueueTests(helper.CPWebCase):
     setup_server = staticmethod(setup_upload_server)
 
-    @pytest.mark.xfail(reason='#1535')
     def test_queue_full(self):
         conns = []
         overflow_conn = None


### PR DESCRIPTION
Closes #1535 

This test passes consistently on Travis CI so perhaps [resolving #1839 fixed #1535](https://github.com/cherrypy/cherrypy/issues/1535#issuecomment-581424282).
* https://travis-ci.org/github/cherrypy/cherrypy/jobs/743848193#L594
* https://travis-ci.org/github/cherrypy/cherrypy/jobs/743848194#L598
* https://travis-ci.org/github/cherrypy/cherrypy/jobs/743848195#L645

Combining this PR with #1886 should allow CircleCI Linux to pass.

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
