### PR TITLE
tox.ini: pytest --full-trace for KeyboardInterrupt traceback

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ usedevelop = True
 commands_pre =
     pip install -U setuptools
 commands =
-    pytest {posargs}
+    pytest --full-trace {posargs}
     codecov -f coverage.xml -X gcov
 passenv =
   WEBTEST_INTERACTIVE


### PR DESCRIPTION
Pytest currently raises:
```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/home/travis/build/cherrypy/cherrypy/.tox/python/lib/python3.7/site-packages/cheroot/server.py:2061: KeyboardInterrupt
(to show a full traceback on KeyboardInterrupt use --full-trace)
```

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
