### PR TITLE
Fork and xfail test_2_KeyboardInterrupt on CI

### DIFF
--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -161,12 +161,14 @@ class ServerStateTests(helper.CPWebCase):
         self.assertEqual(db_connection.running, False)
         self.assertEqual(len(db_connection.threads), 0)
 
-    @pytest.mark.skipif(os.name == 'nt', 'see pytest-dev/pytest-forked#44')
+    # @pytest.mark.skipif(os.name == 'nt', 'see pytest-dev/pytest-forked#44')
     @pytest.mark.forked
     @pytest.mark.xfail(bool(os.getenv('CI')), reason='KeyboardInterrupt #1873')
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.
         # We must start the server in this, the main thread
+        if os.name == 'nt':
+            return  # Workaround for the pytest.mark.skipif() above.
         engine.start()
         cherrypy.server.start()
 

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -161,14 +161,9 @@ class ServerStateTests(helper.CPWebCase):
         self.assertEqual(db_connection.running, False)
         self.assertEqual(len(db_connection.threads), 0)
 
+    @pytest.mark.skipif(os.name == 'nt', 'see pytest-dev/pytest-forked#44')
     @pytest.mark.forked
-    @pytest.mark.xfail(
-        bool(os.getenv('CI')),
-        reason=(
-            'fails on Windows because of pytest-dev/pytest-forked#44 and '
-            'on other OSes because of #1873'
-        )
-    )
+    @pytest.mark.xfail(bool(os.getenv('CI')), reason='KeyboardInterrupt #1873')
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.
         # We must start the server in this, the main thread

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -163,7 +163,8 @@ class ServerStateTests(helper.CPWebCase):
 
     @pytest.mark.forked
     @pytest.mark.xfail(
-        bool(os.getenv("CI")), reason="continuous integration fails keyboard interrupts"
+        bool(os.getenv('CI')),
+        reason='keyboard interrupts fail on continuous integration'
     )
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -161,9 +161,7 @@ class ServerStateTests(helper.CPWebCase):
         self.assertEqual(db_connection.running, False)
         self.assertEqual(len(db_connection.threads), 0)
 
-    @pytest.mark.skipif(os.name == 'nt', 'see pytest-dev/pytest-forked#44')
-    @pytest.mark.xfail(reason='KeyboardInterrupt error #1873')
-    @pytest.mark.forked
+    @pytest.mark.xfail(reason='KeyboardInterrupt #1873', run=(os.name != 'nt'))
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.
         # We must start the server in this, the main thread

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -165,8 +165,6 @@ class ServerStateTests(helper.CPWebCase):
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.
         # We must start the server in this, the main thread
-        if os.name == 'nt':
-            return  # Workaround for the pytest.mark.skipif() above.
         engine.start()
         cherrypy.server.start()
 

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -164,7 +164,10 @@ class ServerStateTests(helper.CPWebCase):
     @pytest.mark.forked
     @pytest.mark.xfail(
         bool(os.getenv('CI')),
-        reason='keyboard interrupts fail on continuous integration'
+        reason=(
+                'fails on Windows because of pytest-dev/pytest-forked#44 and '
+                'on other OSes because of #1873'
+        )
     )
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -161,6 +161,10 @@ class ServerStateTests(helper.CPWebCase):
         self.assertEqual(db_connection.running, False)
         self.assertEqual(len(db_connection.threads), 0)
 
+    @pytest.mark.forked
+    @pytest.mark.xfail(
+        bool(os.getenv("CI")), reason="continuous integration fails keyboard interrupts"
+    )
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.
         # We must start the server in this, the main thread

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -161,9 +161,9 @@ class ServerStateTests(helper.CPWebCase):
         self.assertEqual(db_connection.running, False)
         self.assertEqual(len(db_connection.threads), 0)
 
-    # @pytest.mark.skipif(os.name == 'nt', 'see pytest-dev/pytest-forked#44')
+    @pytest.mark.skipif(os.name == 'nt', 'see pytest-dev/pytest-forked#44')
+    @pytest.mark.xfail(reason='KeyboardInterrupt error #1873')
     @pytest.mark.forked
-    @pytest.mark.xfail(bool(os.getenv('CI')), reason='KeyboardInterrupt #1873')
     def test_2_KeyboardInterrupt(self):
         # Raise a keyboard interrupt in the HTTP server's main thread.
         # We must start the server in this, the main thread

--- a/cherrypy/test/test_states.py
+++ b/cherrypy/test/test_states.py
@@ -165,8 +165,8 @@ class ServerStateTests(helper.CPWebCase):
     @pytest.mark.xfail(
         bool(os.getenv('CI')),
         reason=(
-                'fails on Windows because of pytest-dev/pytest-forked#44 and '
-                'on other OSes because of #1873'
+            'fails on Windows because of pytest-dev/pytest-forked#44 and '
+            'on other OSes because of #1873'
         )
     )
     def test_2_KeyboardInterrupt(self):

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ params = dict(
 
             'pytest>=5.3.5',
             'pytest-cov',
+            'pytest-forked',
             'pytest-sugar',
             'path.py',
             'requests_toolbelt',


### PR DESCRIPTION
As discussed in  #1877 and based on the lessons learned in #1885.

Combining this PR with #1884 should allow CircleCI Linux to pass.

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
