### PR TITLE
Fix `test_block()` to ignore the final message with a thread name

### DIFF
--- a/cherrypy/test/test_bus.py
+++ b/cherrypy/test/test_bus.py
@@ -269,7 +269,11 @@ def test_block(bus, log_tracker):
         'Waiting for child threads to terminate...',
     ]
     # If the last message mentions an indeterminable thread name then ignore it
-    assert expected in (log_tracker.log_entries, log_tracker.log_entries[:-1])
+    len_expected = len(expected)
+    assert log_tracker.log_entries[:len_expected] == expected
+    assert len(log_tracker.log_entries[len_expected:]) - len_expected in (0, 1), (
+        'No more than one extra log line with the thread name expected'
+    )
 
 
 def test_start_with_callback(bus):

--- a/cherrypy/test/test_bus.py
+++ b/cherrypy/test/test_bus.py
@@ -271,7 +271,7 @@ def test_block(bus, log_tracker):
     # If the last message mentions an indeterminable thread name then ignore it
     len_expected = len(expected)
     assert log_tracker.log_entries[:len_expected] == expected
-    assert len(log_tracker.log_entries) - len_expected in (0, 1), (
+    assert len(log_tracker.log_entries) - len_expected <= 1, (
         'No more than one extra log line with the thread name expected'
     )
 

--- a/cherrypy/test/test_bus.py
+++ b/cherrypy/test/test_bus.py
@@ -271,7 +271,7 @@ def test_block(bus, log_tracker):
     # If the last message mentions an indeterminable thread name then ignore it
     len_expected = len(expected)
     assert log_tracker.log_entries[:len_expected] == expected
-    assert len(log_tracker.log_entries[len_expected:]) - len_expected in (0, 1), (
+    assert len(log_tracker.log_entries) - len_expected in (0, 1), (
         'No more than one extra log line with the thread name expected'
     )
 

--- a/cherrypy/test/test_bus.py
+++ b/cherrypy/test/test_bus.py
@@ -261,10 +261,15 @@ def test_block(bus, log_tracker):
 
     # The last message will mention an indeterminable thread name; ignore
     # it
-    assert (log_tracker.log_entries[:-1] ==
-            ['Bus STOPPING', 'Bus STOPPED',
-             'Bus EXITING', 'Bus EXITED',
-             'Waiting for child threads to terminate...'])
+    expected = [
+        "Bus STOPPING",
+        "Bus STOPPED",
+        "Bus EXITING",
+        "Bus EXITED",
+        "Waiting for child threads to terminate...",
+    ]
+    # If the last message mentions an indeterminable thread name then ignore it
+    assert expected in (log_tracker.log_entries, log_tracker.log_entries[:-1])
 
 
 def test_start_with_callback(bus):

--- a/cherrypy/test/test_bus.py
+++ b/cherrypy/test/test_bus.py
@@ -262,11 +262,11 @@ def test_block(bus, log_tracker):
     # The last message will mention an indeterminable thread name; ignore
     # it
     expected = [
-        "Bus STOPPING",
-        "Bus STOPPED",
-        "Bus EXITING",
-        "Bus EXITED",
-        "Waiting for child threads to terminate...",
+        'Bus STOPPING',
+        'Bus STOPPED',
+        'Bus EXITING',
+        'Bus EXITED',
+        'Waiting for child threads to terminate...',
     ]
     # If the last message mentions an indeterminable thread name then ignore it
     assert expected in (log_tracker.log_entries, log_tracker.log_entries[:-1])


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other

**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)

Continuous Integration tests fail.

**What is the new behavior (if this is a feature change)?**

Continuous Integration tests fail.

**Other Information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
