### PR TITLE
Travis CI: Upgrade mainstream_python from 3.7 to 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ _base_envs:
   - brew --cache
   script:
   - travis_retry python -m tox
-- &python_3_7_mixture
-  python: &mainstream_python 3.7
+- &python_3_8_mixture
+  python: &mainstream_python 3.8
   group:
 - &pure_python_base
   <<: *stage_test
-  <<: *python_3_7_mixture
+  <<: *python_3_8_mixture
 - &pure_python_base_priority
   <<: *pure_python_base
   <<: *stage_test_priority
@@ -97,9 +97,9 @@ jobs:
       (non-strict until \#1797 get fixed)
     env: TOXENV=build-docs
   - <<: *pure_python_base_priority
-    # mainstream here (3.7)
+    # mainstream Python here
   - <<: *pure_python_base_priority
-    # mainstream here (3.7)
+    # mainstream Python here
     # run tests against the bleeding-edge cheroot
     env: TOXENV=cheroot-master
   - <<: *pure_python_base_priority
@@ -123,16 +123,16 @@ jobs:
     - *env_pyenv
     - *env_path
   - <<: *osx_python_base
-    # mainstream here (3.7)
+    # mainstream Python here
     python: *mainstream_python
     env:
-    - PYTHON_VERSION=3.7.0
+    - PYTHON_VERSION=3.8.6
     # run tests against the bleeding-edge cheroot
     - TOXENV=cheroot-master
     - *env_pyenv
     - *env_path
   - <<: *stage_deploy
-    <<: *python_3_7_mixture
+    <<: *python_3_8_mixture
     <<: *no_memcached
     install: skip
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ jobs:
     # mainstream Python here
     python: *mainstream_python
     env:
-    - PYTHON_VERSION=3.8.6
+    - PYTHON_VERSION=3.7.0
     # run tests against the bleeding-edge cheroot
     - TOXENV=cheroot-master
     - *env_pyenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ _base_envs:
   - brew --cache
   script:
   - travis_retry python -m tox
-- &python_3_8_mixture
-  python: &mainstream_python 3.8
+- &python_3_9_mixture
+  python: &mainstream_python 3.9
   group:
 - &pure_python_base
   <<: *stage_test
-  <<: *python_3_8_mixture
+  <<: *python_3_9_mixture
 - &pure_python_base_priority
   <<: *pure_python_base
   <<: *stage_test_priority
@@ -132,7 +132,7 @@ jobs:
     - *env_pyenv
     - *env_path
   - <<: *stage_deploy
-    <<: *python_3_8_mixture
+    <<: *python_3_9_mixture
     <<: *no_memcached
     install: skip
     script: skip


### PR DESCRIPTION
Travis passes on:
* [x] Python 3.8.3
* [x] Python 3.9.0

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)
Travis tests are passing against Python 3.7 but are failing on CPython nightly (Python 3.10-dev).  This PR attempts to ensure that Travis tests pass on Python 3.8.


**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
