### PR TITLE
test_params.test_syntax() will fail on Python > 3.9

### DIFF
--- a/cherrypy/test/test_params.py
+++ b/cherrypy/test/test_params.py
@@ -43,8 +43,8 @@ class ParamsTest(helper.CPWebCase):
         self.assertStatus(500)
 
     def test_syntax(self):
-        if sys.version_info < (3,):
-            return self.skip('skipped (Python 3 only)')
+        if not (3,) < sys.version_info < (3, 10):
+            return self.skip('skipped (Python 3.0 to 3.9 only)')
         code = textwrap.dedent("""
             class Root:
                 @cherrypy.expose


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
