### PR TITLE
Require setuptools, cherrypy/__init__.py, docs/conf.py, cherrypy/testhelper.py import pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ params = dict(
             'sphinxcontrib-apidoc>=0.3.0',
             'rst.linker>=1.11',
             'jaraco.packaging>=3.2',
+            'setuptools',
         ],
         'json': ['simplejson'],
         'routes_dispatcher': ['routes>=2.3.1'],
@@ -94,6 +95,7 @@ params = dict(
             'path.py',
             'requests_toolbelt',
             'pytest-services>=2',
+            'setuptools',
         ],
         # Enables memcached session support via `cherrypy[memcached_session]`:
         'memcached_session': ['python-memcached>=1.58'],


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)
pkg_resources needs setuptools as a runtime dependency. Since it wasn't specified so far, there was a possibility of `ModuleNotFoundError: No module named 'pkg_resources'` in case of setuptools not being present. There is a way how to install packages without setuptools or setuptools can be uninstalled after cherypy package was installed. My PR prevents this error.


**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
