### PR TITLE
Use modern threading API instead of deprecated pre-/2.6 camelCase names

### DIFF
--- a/cherrypy/process/plugins.py
+++ b/cherrypy/process/plugins.py
@@ -366,7 +366,7 @@ class Daemonizer(SimplePlugin):
         # "The general problem with making fork() work in a multi-threaded
         #  world is what to do with all of the threads..."
         # So we check for active threads:
-        if threading.activeCount() != 1:
+        if threading.active_count() != 1:
             self.bus.log('There are %r active threads. '
                          'Daemonizing now may cause strange failures.' %
                          threading.enumerate(), level=30)
@@ -552,7 +552,7 @@ class Monitor(SimplePlugin):
             if self.thread is None:
                 self.thread = BackgroundTask(self.frequency, self.callback,
                                              bus=self.bus)
-                self.thread.setName(threadname)
+                self.thread.name = threadname
                 self.thread.start()
                 self.bus.log('Started monitor thread %r.' % threadname)
             else:
@@ -565,8 +565,8 @@ class Monitor(SimplePlugin):
             self.bus.log('No thread running for %s.' %
                          self.name or self.__class__.__name__)
         else:
-            if self.thread is not threading.currentThread():
-                name = self.thread.getName()
+            if self.thread is not threading.current_thread():
+                name = self.thread.name
                 self.thread.cancel()
                 if not self.thread.daemon:
                     self.bus.log('Joining %r' % name)
@@ -692,7 +692,7 @@ class Autoreloader(Monitor):
                                      filename)
                         self.thread.cancel()
                         self.bus.log('Stopped thread %r.' %
-                                     self.thread.getName())
+                                     self.thread.name)
                         self.bus.restart()
                         return
 

--- a/cherrypy/process/servers.py
+++ b/cherrypy/process/servers.py
@@ -178,7 +178,7 @@ class ServerAdapter(object):
 
         import threading
         t = threading.Thread(target=self._start_http_thread)
-        t.setName('HTTPServer ' + t.getName())
+        t.name = 'HTTPServer ' + t.name
         t.start()
 
         self.wait()

--- a/cherrypy/process/wspbus.py
+++ b/cherrypy/process/wspbus.py
@@ -356,13 +356,13 @@ class Bus(object):
             # implemented as a windows service and in any other case
             # that another thread executes cherrypy.engine.exit()
             if (
-                    t != threading.currentThread() and
+                    t != threading.current_thread() and
                     not isinstance(t, threading._MainThread) and
                     # Note that any dummy (external) threads are
                     # always daemonic.
                     not t.daemon
             ):
-                self.log('Waiting for thread %s.' % t.getName())
+                self.log('Waiting for thread %s.' % t.name)
                 t.join()
 
         if self.execv:
@@ -570,7 +570,7 @@ class Bus(object):
             self.wait(states.STARTED)
             func(*a, **kw)
         t = threading.Thread(target=_callback, args=args, kwargs=kwargs)
-        t.setName('Bus Callback ' + t.getName())
+        t.name = 'Bus Callback ' + t.name
         t.start()
 
         self.start()


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

Fixes #1914



**What is the current behavior?** (You can also link to an open issue here)

Deprecation warnings are emitted for camelCase aliases in the threading module.


**What is the new behavior (if this is a feature change)?**

The functions map as follows:

* `t.activeCount()` -> `t.active_count()`
* `t.currentThread()` -> `t.current_thread()`
* `t.getName()` ->  `t.name`
* `t.setName(x)` -> `t.name = x`


**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
