### PR TITLE
Replace links to cherrypy.org with cherrypy.dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@
    :target: https://codecov.io/gh/cherrypy/cherrypy
    :alt: codecov
 
-Welcome to the GitHub repository of `CherryPy <https://cherrypy.org/>`_!
+Welcome to the GitHub repository of `CherryPy <https://cherrypy.rtfd.io>`_!
 
 CherryPy is a pythonic, object-oriented HTTP framework.
 
@@ -84,7 +84,7 @@ and/or API.
 
 While CherryPy is one of the easiest and most intuitive frameworks out
 there, the prerequisite for understanding the `CherryPy
-documentation <https://docs.cherrypy.org/en/latest/>`_ is that you have
+documentation <https://cherrypy.readthedocs.io/en/latest/>`_ is that you have
 a general understanding of Python and web development.
 Additionally:
 
@@ -95,7 +95,7 @@ Additionally:
 
 If the docs are insufficient to address your needs, the CherryPy
 community has several `avenues for support
-<https://docs.cherrypy.org/en/latest/support.html>`_.
+<https://cherrypy.readthedocs.io/en/latest/support.html>`_.
 
 For Enterprise
 --------------
@@ -112,6 +112,6 @@ Contributing
 ------------
 
 Please follow the `contribution guidelines
-<https://docs.cherrypy.org/en/latest/contribute.html>`_.
+<https://cherrypy.readthedocs.io/en/latest/contribute.html>`_.
 And by all means, absorb the `Zen of
 CherryPy <https://github.com/cherrypy/cherrypy/wiki/The-Zen-of-CherryPy>`_.

--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@
    :target: https://codecov.io/gh/cherrypy/cherrypy
    :alt: codecov
 
-Welcome to the GitHub repository of `CherryPy <https://cherrypy.rtfd.io>`_!
+Welcome to the GitHub repository of `CherryPy <https://cherrypy.dev>`_!
 
 CherryPy is a pythonic, object-oriented HTTP framework.
 
@@ -84,7 +84,7 @@ and/or API.
 
 While CherryPy is one of the easiest and most intuitive frameworks out
 there, the prerequisite for understanding the `CherryPy
-documentation <https://cherrypy.readthedocs.io/en/latest/>`_ is that you have
+documentation <https://docs.cherrypy.dev>`_ is that you have
 a general understanding of Python and web development.
 Additionally:
 
@@ -95,7 +95,7 @@ Additionally:
 
 If the docs are insufficient to address your needs, the CherryPy
 community has several `avenues for support
-<https://cherrypy.readthedocs.io/en/latest/support.html>`_.
+<https://docs.cherrypy.dev/en/latest/support.html>`_.
 
 For Enterprise
 --------------
@@ -112,6 +112,6 @@ Contributing
 ------------
 
 Please follow the `contribution guidelines
-<https://cherrypy.readthedocs.io/en/latest/contribute.html>`_.
+<https://docs.cherrypy.dev/en/latest/contribute.html>`_.
 And by all means, absorb the `Zen of
 CherryPy <https://github.com/cherrypy/cherrypy/wiki/The-Zen-of-CherryPy>`_.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [x] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)
Reame document was having broken links to https://cherrypy.org/, which is not accessible anymore


**What is the new behavior (if this is a feature change)?**
Links have been changed to use https://cherrypy.readthedocs.io/ as the endpoint


**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
