### PR TITLE
added brotli compression support

### DIFF
--- a/cherrypy/_cptools.py
+++ b/cherrypy/_cptools.py
@@ -480,6 +480,7 @@ _d.decode = Tool('before_request_body', encoding.decode)
 # the order of encoding, gzip, caching is important
 _d.encode = Tool('before_handler', encoding.ResponseEncoder, priority=70)
 _d.gzip = Tool('before_finalize', encoding.gzip, priority=80)
+_d.br = Tool('before_finalize', encoding.brotli_tool, priority=80)
 _d.staticdir = HandlerTool(static.staticdir)
 _d.staticfile = HandlerTool(static.staticfile)
 _d.sessions = SessionTool()

--- a/cherrypy/lib/encoding.py
+++ b/cherrypy/lib/encoding.py
@@ -11,6 +11,9 @@ from cherrypy.lib import set_vary_header
 
 _COMPRESSION_LEVEL_FAST = 1
 _COMPRESSION_LEVEL_BEST = 9
+_COMPRESSION_GZIP       = 'gzip'
+_COMPRESSION_BROTLI     = 'br'
+_COMPRESSION_ALL        = {_COMPRESSION_GZIP, _COMPRESSION_BROTLI}
 
 
 def decode(encoding=None, default_encoding='utf-8'):
@@ -285,7 +288,7 @@ def prepare_iter(value):
 # GZIP
 
 
-def compress(body, compress_level):
+def gzip_compress(body, compress_level):
     """Compress 'body' at the given compress_level."""
     import zlib
 
@@ -365,20 +368,60 @@ def gzip(compress_level=5, mime_types=['text/html', 'text/plain'],
     request = cherrypy.serving.request
     response = cherrypy.serving.response
 
+    apply_weighted_compression_method(request, response, 'TOOLS.GZIP',
+        compress_level=compress_level, mime_types=mime_types, debug=debug)
+
+
+# BROTLI
+
+def apply_weighted_compression_method(request, response, context,
+        compress_level=5, mime_types=['text/html', 'text/plain'], debug=False):
+    """This function is called by the compression tools gzip and br (brotli).
+
+    Try to compress the response based on the enabled tools (gzip/br) and
+    also take into account the weigthed accepted encodings.
+
+    No compression is performed if the response header already contains
+    a content encoding of 'br' or 'gzip' to prevent compressing the content
+    multiple times.
+
+    Additionally no compression is performed if any of the following hold:
+        * The client sends no Accept-Encoding request header
+        * No accepted encoding is present in the Accept-Encoding header
+        * No accepted encoding with a qvalue > 0 is present
+        * The 'identity' value is given with a qvalue > 0.
+    """
     set_vary_header(response, 'Accept-Encoding')
 
     if not response.body:
         # Response body is empty (might be a 304 for instance)
         if debug:
-            cherrypy.log('No response body', context='TOOLS.GZIP')
+            cherrypy.log('No response body', context=context)
         return
 
-    # If returning cached content (which should already have been gzipped),
-    # don't re-zip.
+    # If returning cached content (which should already have been compresses),
+    # don't re-compress.
     if getattr(request, 'cached', False):
         if debug:
-            cherrypy.log('Not gzipping cached response', context='TOOLS.GZIP')
+            cherrypy.log('Not compressing cached response', context=context)
         return
+
+    ce = response.headers.get('Content-Encoding', '')
+    if ce in _COMPRESSION_ALL:
+        if debug:
+            cherrypy.log('Content is already compressed', context=context)
+        return None
+
+    # Check which compression methods are enabled for the current path
+    enabled_methods = set()
+    toolmap = cherrypy.serving.request.toolmaps.get('tools', {})
+    for name, settings in toolmap.items():
+        if(name in _COMPRESSION_ALL) and settings.get('on', False):
+            enabled_methods.add(name)
+    if not enabled_methods:
+        if debug:
+            cherrypy.log('No compression tools configured', context=context)
+        return None
 
     acceptable = request.headers.elements('Accept-Encoding')
     if not acceptable:
@@ -390,65 +433,115 @@ def gzip(compress_level=5, mime_types=['text/html', 'text/plain'],
         # information that a different content-coding is meaningful
         # to the client.
         if debug:
-            cherrypy.log('No Accept-Encoding', context='TOOLS.GZIP')
-        return
+            cherrypy.log('No Accept-Encoding', context=context)
+        return None
 
-    ct = response.headers.get('Content-Type', '').split(';')[0]
+    # Compile a list of compression method candidates
+    # Do not use a set, we want to treat 'gzip' and 'x-gzip' differently
+    candidates = []
     for coding in acceptable:
         if coding.value == 'identity' and coding.qvalue != 0:
             if debug:
                 cherrypy.log('Non-zero identity qvalue: %s' % coding,
-                             context='TOOLS.GZIP')
-            return
-        if coding.value in ('gzip', 'x-gzip'):
-            if coding.qvalue == 0:
-                if debug:
-                    cherrypy.log('Zero gzip qvalue: %s' % coding,
-                                 context='TOOLS.GZIP')
-                return
+                             context=context)
+            return None
+        elif (coding.value in ('br', 'x-br')) and (_COMPRESSION_BROTLI in enabled_methods):
+                candidates.append((coding.qvalue, _COMPRESSION_BROTLI))
+        elif (coding.value in ('gzip', 'x-gzip')) and (_COMPRESSION_GZIP in enabled_methods):
+            candidates.append((coding.qvalue, _COMPRESSION_GZIP))
 
-            if ct not in mime_types:
-                # If the list of provided mime-types contains tokens
-                # such as 'text/*' or 'application/*+xml',
-                # we go through them and find the most appropriate one
-                # based on the given content-type.
-                # The pattern matching is only caring about the most
-                # common cases, as stated above, and doesn't support
-                # for extra parameters.
-                found = False
-                if '/' in ct:
-                    ct_media_type, ct_sub_type = ct.split('/')
-                    for mime_type in mime_types:
-                        if '/' in mime_type:
-                            media_type, sub_type = mime_type.split('/')
-                            if ct_media_type == media_type:
-                                if sub_type == '*':
+    if(candidates):
+        # get compression method from candidates
+        # sort by weight (qvalue) descending, name ascending (to prefer 'br' over 'gzip')
+        qvalue, cm = sorted(candidates, key=lambda x:(-x[0],x[1]))[0]
+        if debug:
+            cherrypy.log('Weighted Compression Method: %s' % cm, context=context)
+        if qvalue == 0:
+            if debug:
+                cherrypy.log('Zero qvalue: %s' % cm, context=context)
+            return
+        ct = response.headers.get('Content-Type', '').split(';')[0]
+        if ct not in mime_types:
+            # If the list of provided mime-types contains tokens
+            # such as 'text/*' or 'application/*+xml',
+            # we go through them and find the most appropriate one
+            # based on the given content-type.
+            # The pattern matching is only caring about the most
+            # common cases, as stated above, and doesn't support
+            # for extra parameters.
+            found = False
+            if '/' in ct:
+                ct_media_type, ct_sub_type = ct.split('/')
+                for mime_type in mime_types:
+                    if '/' in mime_type:
+                        media_type, sub_type = mime_type.split('/')
+                        if ct_media_type == media_type:
+                            if sub_type == '*':
+                                found = True
+                                break
+                            elif '+' in sub_type and '+' in ct_sub_type:
+                                ct_left, ct_right = ct_sub_type.split('+')
+                                left, right = sub_type.split('+')
+                                if left == '*' and ct_right == right:
                                     found = True
                                     break
-                                elif '+' in sub_type and '+' in ct_sub_type:
-                                    ct_left, ct_right = ct_sub_type.split('+')
-                                    left, right = sub_type.split('+')
-                                    if left == '*' and ct_right == right:
-                                        found = True
-                                        break
 
-                if not found:
-                    if debug:
-                        cherrypy.log('Content-Type %s not in mime_types %r' %
-                                     (ct, mime_types), context='TOOLS.GZIP')
-                    return
+            if not found:
+                if debug:
+                    cherrypy.log('Content-Type %s not in mime_types %r' %
+                                    (ct, mime_types), context=context)
+                return
 
-            if debug:
-                cherrypy.log('Gzipping', context='TOOLS.GZIP')
-            # Return a generator that compresses the page
-            response.headers['Content-Encoding'] = 'gzip'
-            response.body = compress(response.body, compress_level)
-            if 'Content-Length' in response.headers:
-                # Delete Content-Length header so finalize() recalcs it.
-                del response.headers['Content-Length']
+        if debug:
+            cherrypy.log('Compressing content. Method: %s' % cm, context=context)
+        # Return a generator that compresses the page
+        response.headers['Content-Encoding'] = cm
+        if cm == _COMPRESSION_BROTLI:
+            response.body = brotli_compress(response.body, compress_level)
+        elif cm == _COMPRESSION_GZIP:
+            response.body = gzip_compress(response.body, compress_level)
+        if 'Content-Length' in response.headers:
+            # Delete Content-Length header so finalize() recalcs it.
+            del response.headers['Content-Length']
 
-            return
+        return
 
     if debug:
-        cherrypy.log('No acceptable encoding found.', context='GZIP')
-    cherrypy.HTTPError(406, 'identity, gzip').set_response()
+        cherrypy.log('No acceptable encoding found.', context=context)
+
+    enabled_methods.add('identity')
+    cherrypy.HTTPError(406, ', '.join(sorted(enabled_methods))).set_response()
+
+
+def brotli_tool(compress_level=5, mime_types=['text/html', 'text/plain'],
+         debug=False):
+    """Try to brotli compress the response body if Content-Type in mime_types.
+
+    cherrypy.response.headers['Content-Type'] must be set to one of the
+    values in the mime_types arg before calling this function.
+
+    The provided list of mime-types must be of one of the following form:
+        * `type/subtype`
+        * `type/*`
+        * `type/*+subtype`
+
+    No compression is performed if any of the following hold:
+        * The client sends no Accept-Encoding request header
+        * No 'br' or 'x-br' is present in the Accept-Encoding header
+        * No 'br' or 'x-br' with a qvalue > 0 is present
+        * The 'identity' value is given with a qvalue > 0.
+
+    """
+    request = cherrypy.serving.request
+    response = cherrypy.serving.response
+
+    apply_weighted_compression_method(request, response, 'TOOLS.BROTLI',
+        compress_level=compress_level, mime_types=mime_types, debug=debug)
+
+
+def brotli_compress(body, compress_level):
+    """Compress 'body' at the given compress_level."""
+    import brotli
+
+    for line in body:
+        yield brotli.compress(line, quality=compress_level)

--- a/cherrypy/test/test_encoding.py
+++ b/cherrypy/test/test_encoding.py
@@ -11,6 +11,11 @@ from cherrypy._cpcompat import ntob, ntou
 
 from cherrypy.test import helper
 
+try:
+    import brotli
+    HAS_BROTLI = True
+except ImportError:
+    HAS_BROTLI = False
 
 europoundUnicode = ntou('£', encoding='utf-8')
 sing = ntou('毛泽东: Sing, Little Birdie?', encoding='utf-8')
@@ -95,6 +100,18 @@ class EncodingTests(helper.CPWebCase):
                 raise IndexError()
                 yield 'Here be dragons'
 
+        class BROTLI:
+
+            @cherrypy.expose
+            def index(self):
+                yield 'Hello, world'
+
+        class BROTLI_GZIP:
+
+            @cherrypy.expose
+            def index(self):
+                yield 'Hello, world'
+
         class Decode:
 
             @cherrypy.expose
@@ -117,8 +134,15 @@ class EncodingTests(helper.CPWebCase):
 
         root = Root()
         root.gzip = GZIP()
+        root.brotli = BROTLI()
+        root.br_gzip = BROTLI_GZIP()
         root.decode = Decode()
-        cherrypy.tree.mount(root, config={'/gzip': {'tools.gzip.on': True}})
+        config = {
+            '/gzip': {'tools.gzip.on': True},
+            '/brotli': {'tools.br.on': HAS_BROTLI},
+            '/br_gzip': {'tools.br.on': HAS_BROTLI, 'tools.gzip.on': True},
+        }
+        cherrypy.tree.mount(root, config=config)
 
     def test_query_string_decoding(self):
         URI_TMPL = '/reqparams?q={q}'
@@ -377,6 +401,11 @@ class EncodingTests(helper.CPWebCase):
         self.assertHeader('Vary', 'Accept-Encoding')
         self.assertHeader('Content-Encoding', 'gzip')
 
+        self.getPage('/gzip/', headers=[('Accept-Encoding', 'gzip, br')])
+        self.assertInBody(zbuf.getvalue()[:3])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertHeader('Content-Encoding', 'gzip')
+
         # Test when gzip is denied.
         self.getPage('/gzip/', headers=[('Accept-Encoding', 'identity')])
         self.assertHeader('Vary', 'Accept-Encoding')
@@ -397,7 +426,7 @@ class EncodingTests(helper.CPWebCase):
         self.getPage('/gzip/', headers=[('Accept-Encoding', '*;q=0')])
         self.assertStatus(406)
         self.assertNoHeader('Content-Encoding')
-        self.assertErrorPage(406, 'identity, gzip')
+        self.assertErrorPage(406, 'gzip, identity')
 
         # Test for ticket #147
         self.getPage('/gzip/noshow', headers=[('Accept-Encoding', 'gzip')])
@@ -421,6 +450,55 @@ class EncodingTests(helper.CPWebCase):
             self.assertRaises((ValueError, IncompleteRead), self.getPage,
                               '/gzip/noshow_stream',
                               headers=[('Accept-Encoding', 'gzip')])
+
+    def testBrotli(self):
+        if not HAS_BROTLI:
+            return
+
+        import brotli
+
+        self.getPage('/brotli/', headers=[('Accept-Encoding', 'br')])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertHeader('Content-Encoding', 'br')
+        self.assertBody(brotli.compress(b'Hello, world', quality=5))
+
+        self.getPage('/brotli/', headers=[('Accept-Encoding', 'gzip, deflate, br')])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertHeader('Content-Encoding', 'br')
+        self.assertBody(brotli.compress(b'Hello, world', quality=5))
+
+    def testBrotliGzip(self):
+        if not HAS_BROTLI:
+            return
+
+        import brotli
+
+        self.getPage('/br_gzip/', headers=[('Accept-Encoding', 'br')])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertHeader('Content-Encoding', 'br')
+        self.assertBody(brotli.compress(b'Hello, world', quality=5))
+
+        self.getPage('/br_gzip/', headers=[('Accept-Encoding', 'gzip')])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertHeader('Content-Encoding', 'gzip')
+
+        self.getPage('/br_gzip/', headers=[('Accept-Encoding', 'gzip;q=0.2, br;q=0.8')])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertHeader('Content-Encoding', 'br')
+
+        self.getPage('/br_gzip/', headers=[('Accept-Encoding', 'gzip;q=0.8, br;q=0.2')])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertHeader('Content-Encoding', 'gzip')
+
+        self.getPage('/br_gzip/', headers=[('Accept-Encoding', 'identity')])
+        self.assertHeader('Vary', 'Accept-Encoding')
+        self.assertNoHeader('Content-Encoding')
+        self.assertBody('Hello, world')
+
+        self.getPage('/br_gzip/', headers=[('Accept-Encoding', '*;q=0')])
+        self.assertStatus(406)
+        self.assertNoHeader('Content-Encoding')
+        self.assertErrorPage(406, 'br, gzip, identity')
 
     def test_UnicodeHeaders(self):
         self.getPage('/cookies_and_headers')

--- a/cherrypy/test/test_encoding.py
+++ b/cherrypy/test/test_encoding.py
@@ -460,12 +460,14 @@ class EncodingTests(helper.CPWebCase):
         self.getPage('/brotli/', headers=[('Accept-Encoding', 'br')])
         self.assertHeader('Vary', 'Accept-Encoding')
         self.assertHeader('Content-Encoding', 'br')
-        self.assertBody(brotli.compress(b'Hello, world', quality=5))
+        self.assertBody(brotli.compress(b'Hello, world',
+                quality=cherrypy.lib.encoding._COMPRESSION_LEVEL_DEFAULTS['br']))
 
         self.getPage('/brotli/', headers=[('Accept-Encoding', 'gzip, deflate, br')])
         self.assertHeader('Vary', 'Accept-Encoding')
         self.assertHeader('Content-Encoding', 'br')
-        self.assertBody(brotli.compress(b'Hello, world', quality=5))
+        self.assertBody(brotli.compress(b'Hello, world',
+                quality=cherrypy.lib.encoding._COMPRESSION_LEVEL_DEFAULTS['br']))
 
     def testBrotliGzip(self):
         if not HAS_BROTLI:
@@ -476,7 +478,8 @@ class EncodingTests(helper.CPWebCase):
         self.getPage('/br_gzip/', headers=[('Accept-Encoding', 'br')])
         self.assertHeader('Vary', 'Accept-Encoding')
         self.assertHeader('Content-Encoding', 'br')
-        self.assertBody(brotli.compress(b'Hello, world', quality=5))
+        self.assertBody(brotli.compress(b'Hello, world',
+                quality=cherrypy.lib.encoding._COMPRESSION_LEVEL_DEFAULTS['br']))
 
         self.getPage('/br_gzip/', headers=[('Accept-Encoding', 'gzip')])
         self.assertHeader('Vary', 'Accept-Encoding')

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ params = dict(
             'requests_toolbelt',
             'pytest-services>=2',
             'setuptools',
+            'brotli',
         ],
         # Enables memcached session support via `cherrypy[memcached_session]`:
         'memcached_session': ['python-memcached>=1.58'],


### PR DESCRIPTION
brotli compression can be enabled just like gzip compression by setting ``'tools.br.on': True,``

``tools.br`` may also be combined with ``'tools.gzip`` - the client can then decide which encoding is accepted.

If both ``gzip`` and ``br`` tools are enabled and both ``gzip`` and ``br`` are accepted encodings, ``br`` will be chosen over ``gzip`` - unless ``gzip`` has a higher ``qvalue``

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [x] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
