### PR TITLE
Make engine.block() not waiting for non-cherrypy threads to finish

### DIFF
--- a/cherrypy/process/plugins.py
+++ b/cherrypy/process/plugins.py
@@ -10,6 +10,7 @@ import _thread
 
 from cherrypy._cpcompat import text_or_bytes
 from cherrypy._cpcompat import ntob
+from cherrypy.process import threads
 
 # _module__file__base is used by Autoreload to make
 # absolute any filenames retrieved from sys.modules which are not
@@ -481,7 +482,7 @@ class PerpetualTimer(threading.Timer):
                 raise
 
 
-class BackgroundTask(threading.Thread):
+class BackgroundTask(threads.Thread):
 
     """A subclass of threading.Thread whose run() method repeats.
 

--- a/cherrypy/process/servers.py
+++ b/cherrypy/process/servers.py
@@ -176,8 +176,8 @@ class ServerAdapter(object):
             if isinstance(self.bind_addr, tuple):
                 portend.free(*self.bind_addr, timeout=Timeouts.free)
 
-        import threading
-        t = threading.Thread(target=self._start_http_thread)
+        from cherrypy.process import threads
+        t = threads.Thread(target=self._start_http_thread)
         t.name = 'HTTPServer ' + t.name
         t.start()
 

--- a/cherrypy/process/threads.py
+++ b/cherrypy/process/threads.py
@@ -1,0 +1,8 @@
+"""Base class for threads created by cherrypy."""
+import threading
+
+
+class Thread(threading.Thread):
+    """Base class for threads created by cherrypy."""
+
+    pass


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
#1942 



**What is the current behavior?** (You can also link to an open issue here)
`engine.block()` waits ALL threads to finish before exit/restart and waits forever for concurrent.future threads.


**What is the new behavior (if this is a feature change)?**
`engine.block()` waits only for threads created by cherrypy.


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
