### PR TITLE
Added absolute index flag to staticdir

### DIFF
--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -296,7 +296,7 @@ def _attempt(filename, content_types, debug=False):
 
 
 def staticdir(section, dir, root='', match='', content_types=None, index='',
-              debug=False):
+              abs_index=False, debug=False):
     """Serve a static resource from the given (root +) dir.
 
     match
@@ -314,6 +314,12 @@ def staticdir(section, dir, root='', match='', content_types=None, index='',
         serve for directory requests. For example, if the dir argument is
         '/home/me', the Request-URI is 'myapp', and the index arg is
         'index.html', the file '/home/me/myapp/index.html' will be sought.
+    abs_index
+        If set to True it changes the behavior of index.
+        Now index is the absolute name of a file to serve for directory
+        requests, ignoring the Request-URI. For example, if the dir
+        argument is '/home/me', the Request-URI is 'myapp', and the index
+        arg is 'index.html', the file '/home/me/index.html' will be sought.
     """
     request = cherrypy.serving.request
     if request.method not in ('GET', 'HEAD'):
@@ -371,7 +377,11 @@ def staticdir(section, dir, root='', match='', content_types=None, index='',
     if not handled:
         # Check for an index file if a folder was requested.
         if index:
-            handled = _attempt(os.path.join(filename, index), content_types)
+            if abs_index:
+                handled = _attempt(os.path.join(dir, index), content_types)
+            else:
+                handled = _attempt(
+                    os.path.join(filename, index), content_types)
             if handled:
                 request.is_index = filename[-1] in (r'\/')
     return handled

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -144,6 +144,13 @@ class StaticTest(helper.CPWebCase):
                 'tools.staticdir.dir': 'static',
                 'tools.staticdir.index': 'index.html',
             },
+            '/docrootabs': {
+                'tools.staticdir.on': True,
+                'tools.staticdir.root': curdir,
+                'tools.staticdir.dir': 'static',
+                'tools.staticdir.index': 'index.html',
+                'tools.staticdir.abs_index': True,
+            },
             '/error': {
                 'tools.staticdir.on': True,
                 'request.show_tracebacks': True,
@@ -258,6 +265,28 @@ class StaticTest(helper.CPWebCase):
             '%s/docroot/</a>.'
             % (self.base(), self.base())
         )
+
+    def test_abs_index(self):
+        # Check a directory via "staticdir.index" but not "staticdir.abs_index"
+        # it's not falling back to "staticdir.dir"'s index
+        self.getPage('/docroot/somepath/')
+        self.assertStatus(404)
+        # also deeper path's shouldn't work
+        self.getPage('/docroot/some/even/deeper/path/')
+        self.assertStatus(404)
+        # but with "staticdir.abs_index" set to True all subpath's should
+        # fall back to "staticdir.dir"'s index
+        self.getPage('/docrootabs/somepath/')
+        self.assertStatus('200 OK')
+        self.assertBody('Hello, world\r\n')
+        # even deeper path's should work now
+        self.getPage('/docrootabs/some/even/deeper/path/')
+        self.assertStatus('200 OK')
+        self.assertBody('Hello, world\r\n')
+        # and for sure the basepath
+        self.getPage('/docrootabs/')
+        self.assertStatus('200 OK')
+        self.assertBody('Hello, world\r\n')
 
     def test_config_errors(self):
         # Check that we get an error if no .file or .dir

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -682,6 +682,30 @@ CherryPy will automatically respond to URLs such as
 `http://hostname/static/` by returning its contents.
 
 
+Specifying an absolute index file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Assuming you like to serve a Single Page Application (SPA) like
+Angular under a static directory. These Apps usually bring their
+own routing module for subsequent path's but all index'es of
+this path's need to deliver the root's index on requests like a
+refresh (F5) or copied links. You can accomplish this behavior
+with the `abs_index` flag like here:
+
+.. code-block:: ini
+
+   [/app]
+   tools.staticdir.on = True
+   tools.staticdir.dir = "/home/site/static"
+   tools.staticdir.index = "index.html"
+   tools.staticdir.abs_index = True
+
+Assuming you have the SPA's index at `app/index.html`,
+CherryPy will respond to URLs such as `http://hostname/app/`,
+`http://hostname/app/somepath/` and `http://hostname/app/some/even/deeper/path/`
+by returning its contents.
+
+
 Allow files downloading
 ^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [x] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

#1952 

**What is the current behavior?**

Please refer to #1952 

**What is the new behavior (if this is a feature change)?**

As proposed in my feature request I added the argument `abs_index` to the staticdir function. The default value is False, which does not change the behavior of staticdir as is. But if `abs_index` is set to True the given index -file is no longer searched relative to the Request-URI. Instead it is searched directly under the path given in `dir` argument.

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2]
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
