### PR TITLE
Clean lock files together with session files

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -599,7 +599,7 @@ class FileSession(Session):
                         os.unlink(path + self.LOCK_SUFFIX)
                     except:
                         pass
-                    
+
 
     def __len__(self):
         """Return the number of active sessions."""


### PR DESCRIPTION
When removing a session file, also remove the lock file if it exists. This might be a dirty fix for #1855

**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
#1855 


**What is the current behavior?** (You can also link to an open issue here)
Lock files are not removed, when expired session files are removed by clean-up thread.


**What is the new behavior (if this is a feature change)?**
When removing a session file also try to remove its lock file


**Other information**:
It might be a dirty fix, but for now, it saves admins' efforts to delete the huge amount of obsolete locking files outside of CherryPy.

**Checklist**:

  - [ ] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
