### PR TITLE
Remove lock files when clean up session files

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -592,6 +592,20 @@ class FileSession(Session):
                             os.unlink(path)
                 finally:
                     self.release_lock(path)
+                    
+        # A quick and dirty fix to clean up those lock files that never get removed
+        # Fix for #1855
+        files = [f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)]
+        lock_files = [f for f in files if f.endswith(self.LOCK_SUFFIX)]
+        session_files = list(set(files) - set(lock_files))
+        for fname in lock_files:
+            if fname.replace(self.LOCK_SUFFIX, '') not in session_files:
+                try:
+                    os.unlink(os.path.join(self.storage_path, fname))
+                except OSError:
+                    pass
+
+                    
 
     def __len__(self):
         """Return the number of active sessions."""

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -592,7 +592,7 @@ class FileSession(Session):
                             os.unlink(path)
                 finally:
                     self.release_lock(path)
-                    
+
         # A quick and dirty fix to clean up those lock files that never get removed
         # Fix for #1855
         files = [f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)]
@@ -605,7 +605,7 @@ class FileSession(Session):
                 except OSError:
                     pass
 
-                    
+
 
     def __len__(self):
         """Return the number of active sessions."""

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -597,7 +597,7 @@ class FileSession(Session):
         # Fix for #1855
         files = [f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)]
         lock_files = [f for f in files if f.endswith(self.LOCK_SUFFIX)]
-        session_files = list(set(files) - set(lock_files))
+        session_files = set(files) - set(lock_files)
         for fname in lock_files:
             if fname.replace(self.LOCK_SUFFIX, '') not in session_files:
                 try:

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -592,19 +592,19 @@ class FileSession(Session):
                             os.unlink(path)
                 finally:
                     self.release_lock(path)
-                    
+
         # A quick and dirty fix to clean up those lock files that never get removed
         # Find all lock files, and remove those without session files
         files = {f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)}
         all_lock_files = {f for f in files if f.endswith(self.LOCK_SUFFIX)}
         session_files = files - all_lock_files
-        keep_lock_files = {f + self.LOCK_SUFFIX for f in session_files}        
+        keep_lock_files = {f + self.LOCK_SUFFIX for f in session_files}
         for fname in all_lock_files - keep_lock_files:
             try:
                 os.unlink(os.path.join(self.storage_path, fname))
             except OSError:
                 pass
-       
+
 
     def __len__(self):
         """Return the number of active sessions."""

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -595,11 +595,10 @@ class FileSession(Session):
 
         # A quick and dirty fix to clean up those lock files that never get removed
         # Find all lock files, and remove those without session files
-        files = {f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)}
-        all_lock_files = {f for f in files if f.endswith(self.LOCK_SUFFIX)}
-        session_files = files - all_lock_files
-        keep_lock_files = {f + self.LOCK_SUFFIX for f in session_files}
-        for fname in all_lock_files - keep_lock_files:
+        files = {fname for fname in os.listdir(self.storage_path) if fname.startswith(self.SESSION_PREFIX)}
+        session_files = {fname for fname in files if not fname.endswith(self.LOCK_SUFFIX)}
+        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}        
+        for fname in files - session_files - session_lock_files:
             try:
                 os.unlink(os.path.join(self.storage_path, fname))
             except OSError:

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -569,19 +569,20 @@ class FileSession(Session):
         # Find out all lock files, remove them unless their session files still exit
         all_files = {fname for fname in os.listdir(self.storage_path) if fname.startswith(self.SESSION_PREFIX)}
         lock_files = {fname for fname in all_files if fname.endswith(self.LOCK_SUFFIX)}
-        session_files = {fname for fname in all_files if not fname.endswith(self.LOCK_SUFFIX)}
-        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}
+        session_files = all_files - lock_files
+        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}        
         for fname in lock_files - session_lock_files:
             try:
                 os.unlink(os.path.join(self.storage_path, fname))
             except OSError:
                 pass
-
+                
         # Iterate over all session files in self.storage_path
         for fname in session_files:
             have_session = (
-                fname.startswith(self.SESSION_PREFIX)
-                and not fname.endswith(self.LOCK_SUFFIX)
+                True
+                # fname.startswith(self.SESSION_PREFIX)
+                # and not fname.endswith(self.LOCK_SUFFIX)
             )
             if have_session:
                 # We have a session file: lock and load it and check

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -560,7 +560,7 @@ class FileSession(Session):
         """Release the lock on the currently-loaded session data."""
         self.lock.close()
         self.locked = False
-        if not self._exists():       
+        if not self._exists():
             try:
                 os.unlink(self._get_file_path() + self.LOCK_SUFFIX)
             except OSError:

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -560,11 +560,6 @@ class FileSession(Session):
         """Release the lock on the currently-loaded session data."""
         self.lock.close()
         self.locked = False
-        if not self._exists():
-            try:
-                os.unlink(self._get_file_path() + self.LOCK_SUFFIX)
-            except OSError:
-                pass
 
     def clean_up(self):
         """Clean up expired sessions."""

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -560,6 +560,8 @@ class FileSession(Session):
         """Release the lock on the currently-loaded session data."""
         self.lock.close()
         self.locked = False
+        if not self._exists():
+            os.unlink(self._get_file_path() + self.LOCK_SUFFIX)
 
     def clean_up(self):
         """Clean up expired sessions."""

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -595,16 +595,15 @@ class FileSession(Session):
 
         # A quick and dirty fix to clean up those lock files that never get removed
         # Fix for #1855
-        files = [f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)]
-        lock_files = [f for f in files if f.endswith(self.LOCK_SUFFIX)]
-        session_files = set(files) - set(lock_files)
+        files = {f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)}
+        lock_files = {f for f in files if f.endswith(self.LOCK_SUFFIX)}
+        session_files = files - lock_files
         for fname in lock_files:
             if fname.replace(self.LOCK_SUFFIX, '') not in session_files:
                 try:
                     os.unlink(os.path.join(self.storage_path, fname))
                 except OSError:
                     pass
-
 
 
     def __len__(self):

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -560,8 +560,11 @@ class FileSession(Session):
         """Release the lock on the currently-loaded session data."""
         self.lock.close()
         self.locked = False
-        if not self._exists():
-            os.unlink(self._get_file_path() + self.LOCK_SUFFIX)
+        if not self._exists():       
+            try:
+                os.unlink(self._get_file_path() + self.LOCK_SUFFIX)
+            except OSError:
+                pass
 
     def clean_up(self):
         """Clean up expired sessions."""

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -570,13 +570,13 @@ class FileSession(Session):
         all_files = {fname for fname in os.listdir(self.storage_path) if fname.startswith(self.SESSION_PREFIX)}
         lock_files = {fname for fname in all_files if fname.endswith(self.LOCK_SUFFIX)}
         session_files = all_files - lock_files
-        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}        
+        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}
         for fname in lock_files - session_lock_files:
             try:
                 os.unlink(os.path.join(self.storage_path, fname))
             except OSError:
                 pass
-                
+
         # Iterate over all session files in self.storage_path
         for fname in session_files:
             have_session = (

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -564,19 +564,19 @@ class FileSession(Session):
     def clean_up(self):
         """Clean up expired sessions."""
         now = self.now()
-        
+
         # A quick and dirty fix to clean up those lock files that never get removed
         # Find out all lock files, remove them unless their session files still exit
         all_files = {fname for fname in os.listdir(self.storage_path) if fname.startswith(self.SESSION_PREFIX)}
         lock_files = {fname for fname in all_files if fname.endswith(self.LOCK_SUFFIX)}
         session_files = {fname for fname in all_files if not fname.endswith(self.LOCK_SUFFIX)}
-        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}        
+        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}
         for fname in lock_files - session_lock_files:
             try:
                 os.unlink(os.path.join(self.storage_path, fname))
             except OSError:
                 pass
-                
+
         # Iterate over all session files in self.storage_path
         for fname in session_files:
             have_session = (

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -592,19 +592,19 @@ class FileSession(Session):
                             os.unlink(path)
                 finally:
                     self.release_lock(path)
-
+                    
         # A quick and dirty fix to clean up those lock files that never get removed
-        # Fix for #1855
+        # Find all lock files, and remove those without session files
         files = {f for f in os.listdir(self.storage_path) if f.startswith(self.SESSION_PREFIX)}
-        lock_files = {f for f in files if f.endswith(self.LOCK_SUFFIX)}
-        session_files = files - lock_files
-        for fname in lock_files:
-            if fname.replace(self.LOCK_SUFFIX, '') not in session_files:
-                try:
-                    os.unlink(os.path.join(self.storage_path, fname))
-                except OSError:
-                    pass
-
+        all_lock_files = {f for f in files if f.endswith(self.LOCK_SUFFIX)}
+        session_files = files - all_lock_files
+        keep_lock_files = {f + self.LOCK_SUFFIX for f in session_files}        
+        for fname in all_lock_files - keep_lock_files:
+            try:
+                os.unlink(os.path.join(self.storage_path, fname))
+            except OSError:
+                pass
+       
 
     def __len__(self):
         """Return the number of active sessions."""

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -597,7 +597,7 @@ class FileSession(Session):
         # Find all lock files, and remove those without session files
         files = {fname for fname in os.listdir(self.storage_path) if fname.startswith(self.SESSION_PREFIX)}
         session_files = {fname for fname in files if not fname.endswith(self.LOCK_SUFFIX)}
-        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}        
+        session_lock_files = {fname + self.LOCK_SUFFIX for fname in session_files}
         for fname in files - session_files - session_lock_files:
             try:
                 os.unlink(os.path.join(self.storage_path, fname))


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
#1855 


**What is the current behavior?** (You can also link to an open issue here)
Lock files are not removed, even when expired session files are removed by the clean-up thread.

**What is the new behavior (if this is a feature change)?**
Remove the lock files that have no session files at the end of session clean-up.



**Other Information**:
It might be a dirty fix just to save admins' efforts to delete the huge amount of obsolete locking files outside of CherryPy.



**Checklist**:

  - [ ] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
