### PR TITLE
Adjust traceback-matching patterns in tests for Python 3.11

### DIFF
--- a/cherrypy/test/test_request_obj.py
+++ b/cherrypy/test/test_request_obj.py
@@ -557,7 +557,10 @@ class RequestObjectTests(helper.CPWebCase):
         ignore = helper.webtest.ignored_exceptions
         ignore.append(ValueError)
         try:
-            valerr = '\n    raise ValueError()\nValueError'
+            if sys.version_info >= (3, 11):
+                valerr = '\n    raise ValueError()\n    ^^^^^^^^^^^^^^^^^^\nValueError'
+            else:
+                valerr = '\n    raise ValueError()\nValueError'
             self.getPage('/error/page_method')
             self.assertErrorPage(500, pattern=valerr)
 

--- a/cherrypy/test/test_tools.py
+++ b/cherrypy/test/test_tools.py
@@ -272,7 +272,10 @@ class ToolTests(helper.CPWebCase):
         self.getPage('/demo/ended/1')
         self.assertBody('True')
 
-        valerr = '\n    raise ValueError()\nValueError'
+        if sys.version_info >= (3, 11):
+            valerr = '\n    raise ValueError()\n    ^^^^^^^^^^^^^^^^^^\nValueError'
+        else:
+            valerr = '\n    raise ValueError()\nValueError'
         self.getPage('/demo/err?id=3')
         # If body is "razdrez", then on_end_request is being called too early.
         self.assertErrorPage(502, pattern=valerr)


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

Fedora downstream report: https://bugzilla.redhat.com/show_bug.cgi?id=2081670


**What is the current behavior?** (You can also link to an open issue here)

Test failures.

```
    ERROR: Error page does not contain '\n    raise ValueError()\nValueError' in traceback
```


**What is the new behavior (if this is a feature change)?**

Tests passing.


**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
