### PR TITLE
Fix extra "is" and a missing comma on the docs frontpage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ CherryPy allows developers to build web applications in much the
 same way they would build any other object-oriented Python program.
 This results in smaller source code developed in less time.
 
-CherryPy is now more than ten years old and it is has proven to
+CherryPy is now more than ten years old, and it has proven to
 be fast and reliable. It is being used in production by many
 sites, from the simplest to the most demanding.
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [x] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
