### PR TITLE
Replace python-memcached with pymemcache

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -688,6 +688,7 @@ class MemcachedSession(Session):
 
         from pymemcache.client.hash import HashClient
         from pymemcache import serde
+
         cls.cache = HashClient(cls.servers, serde=serde.pickle_serde)
 
     def _exists(self):

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -686,9 +686,9 @@ class MemcachedSession(Session):
         for k, v in kwargs.items():
             setattr(cls, k, v)
 
-        import memcache
-
-        cls.cache = memcache.Client(cls.servers)
+        from pymemcache.client.hash import HashClient
+        from pymemcache import serde
+        cls.cache = HashClient(cls.servers, serde=serde.pickle_serde)
 
     def _exists(self):
         self.mc_lock.acquire()
@@ -705,8 +705,8 @@ class MemcachedSession(Session):
             self.mc_lock.release()
 
     def _save(self, expiration_time):
-        # Send the expiration time as "Unix time" (seconds since 1/1/1970)
-        td = int(time.mktime(expiration_time.timetuple()))
+        # Seconds to expire from now
+        td = (expiration_time - self.now()).seconds
         self.mc_lock.acquire()
         try:
             if not self.cache.set(self.id, (self._data, expiration_time), td):

--- a/cherrypy/test/test_session.py
+++ b/cherrypy/test/test_session.py
@@ -432,7 +432,7 @@ def memcached_server_present():
 
 @pytest.fixture()
 def memcached_client_present():
-    pytest.importorskip('memcache')
+    pytest.importorskip('pymemcache')
 
 
 @pytest.fixture(scope='session')

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -579,7 +579,7 @@ it is distributed and a good choice if you want to
 share sessions outside of the process running CherryPy.
 
 Requires that the Python
-`memcached package <https://pypi.org/project/memcached>`_
+`memcached package <https://pypi.org/project/pymemcache>`_
 is installed, which may be indicated by installing
 ``cherrypy[memcached_session]``.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -26,7 +26,7 @@ dependencies |project| enables you to specify extras in your requirements (e.g.
 - routes_dispatcher -- `routes <http://routes.readthedocs.org/en/latest/>`_ for declarative URL mapping dispatcher
 - ssl -- for `OpenSSL bindings <https://github.com/pyca/pyopenssl>`_, useful in Python environments not having the builtin :mod:`ssl` module
 - testing
-- memcached_session -- enables `memcached <https://github.com/linsomniac/python-memcached>`_ backend session
+- memcached_session -- enables `memcached <https://github.com/pinterest/pymemcache>`_ backend session
 - xcgi
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ testing = [
 ]
 memcached_session = [
   # Enables memcached session support via `cherrypy[memcached_session]`
-  "python-memcached >= 1.58",
+  "pymemcache",
 ]
 xcgi = [
   "flup",


### PR DESCRIPTION
python-memcached is not maintained, this patch replaces the usage of python-memcached with the pymemcache python package.

Fix https://github.com/cherrypy/cherrypy/issues/1983

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [x] other

**What is the related issue number (starting with `#`)**

#1983 1983

**What is the current behavior?** (You can also link to an open issue here)

Depends on python-memcached

**What is the new behavior (if this is a feature change)?**

Depends on pymemcache

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
