### PR TITLE
Fix `LazyRfc3339UtcTime` to return correct time using UTC timezone

### DIFF
--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -452,6 +452,5 @@ class WSGIErrorHandler(logging.Handler):
 
 class LazyRfc3339UtcTime(object):
     def __str__(self):
-        """Return now() in RFC3339 UTC Format."""
-        now = datetime.datetime.now()
-        return now.isoformat('T') + 'Z'
+        """Return utcnow() in RFC3339 UTC Format."""
+        return f"{datetime.datetime.utcnow().isoformat('T')}Z"

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -453,4 +453,5 @@ class WSGIErrorHandler(logging.Handler):
 class LazyRfc3339UtcTime(object):
     def __str__(self):
         """Return utcnow() in RFC3339 UTC Format."""
-        return f"{datetime.datetime.utcnow().isoformat('T')}Z"
+        iso_formatted_now = datetime.datetime.utcnow().isoformat('T')
+        return f'{iso_formatted_now!s}Z'

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -198,8 +198,7 @@ def test_custom_log_format(log_tracker, monkeypatch, server):
 
 
 def test_utc_in_timez(monkeypatch):
-    """Test utc timestamp is used in
-    cherrypy._cplogging.LazyRfc3339UtcTime"""
+    """Test that ``LazyRfc3339UtcTime`` is rendered as ``str`` using UTC timestamp."""
     import datetime
 
     utcoffset8_local_time_in_naive_utc = (

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -197,6 +197,36 @@ def test_custom_log_format(log_tracker, monkeypatch, server):
     )
 
 
+def test_utc_in_timez(monkeypatch):
+    """Test utc timestamp is used in 
+    cherrypy._cplogging.LazyRfc3339UtcTime"""
+    import datetime
+
+    utcoffset8_local_time_in_naive_utc = (
+        datetime.datetime(
+            year=2020,
+            month=1,
+            day=1,
+            hour=1,
+            minute=23,
+            second=45,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=8)),
+        )
+        .astimezone(datetime.timezone.utc)
+        .replace(tzinfo=None)
+    )
+
+    class mock_datetime:
+        @classmethod
+        def utcnow(cls):
+            return utcoffset8_local_time_in_naive_utc
+
+    monkeypatch.setattr('datetime.datetime', mock_datetime)
+    rfc3339_utc_time = str(cherrypy._cplogging.LazyRfc3339UtcTime())
+    expected_time = '2019-12-31T17:23:45Z'
+    assert rfc3339_utc_time == expected_time
+
+
 def test_timez_log_format(log_tracker, monkeypatch, server):
     """Test a customized access_log_format string, which is a
     feature of _cplogging.LogManager.access()."""

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -198,7 +198,7 @@ def test_custom_log_format(log_tracker, monkeypatch, server):
 
 
 def test_utc_in_timez(monkeypatch):
-    """Test utc timestamp is used in 
+    """Test utc timestamp is used in
     cherrypy._cplogging.LazyRfc3339UtcTime"""
     import datetime
 

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -1,5 +1,6 @@
 """Basic tests for the CherryPy core: request handling."""
 
+import datetime
 import logging
 
 from cheroot.test import webtest
@@ -199,8 +200,6 @@ def test_custom_log_format(log_tracker, monkeypatch, server):
 
 def test_utc_in_timez(monkeypatch):
     """Test that ``LazyRfc3339UtcTime`` is rendered as ``str`` using UTC timestamp."""
-    import datetime
-
     utcoffset8_local_time_in_naive_utc = (
         datetime.datetime(
             year=2020,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other


**What is the related issue number (starting with `#`)**

Fixes #1991

**What is the current behavior?** (You can also link to an open issue here)
#1991


**What is the new behavior (if this is a feature change)?**
It is now return the utc of the local time.


**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
