### PR TITLE
Replace the use of `pkg_resources` with `importlib.metadata`

### DIFF
--- a/cherrypy/__init__.py
+++ b/cherrypy/__init__.py
@@ -57,9 +57,14 @@ These API's are described in the `CherryPy specification
 """
 
 try:
-    import pkg_resources
+    import importlib.metadata as importlib_metadata
 except ImportError:
-    pass
+    # fall back for python <= 3.7
+    # can simply pass when py 3.6/3.7 no longer supported
+    try:
+        import importlib_metadata
+    except ImportError:
+        pass
 
 from threading import local as _local
 
@@ -109,7 +114,7 @@ tree = _cptree.Tree()
 
 
 try:
-    __version__ = pkg_resources.require('cherrypy')[0].version
+    __version__ = importlib_metadata.version('cherrypy')
 except Exception:
     __version__ = 'unknown'
 

--- a/cherrypy/test/helper.py
+++ b/cherrypy/test/helper.py
@@ -461,11 +461,10 @@ server.ssl_private_key: r'%s'
         ```
         ['-c',
          "__requires__ = 'CherryPy'; \
-         import pkg_resources, re, sys; \
+         import importlib.metadata, re, sys; \
          sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0]); \
          sys.exit(\
-            pkg_resources.load_entry_point(\
-                'CherryPy', 'console_scripts', 'cherryd')())"]
+            importlib.metadata.distribution('cherrypy').entry_points[0])"]
         ```
 
         doesn't work as it's impossible to reconstruct the `-c`'s contents.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from email import message_from_string
 import importlib
-import pkg_resources
 import sys
 
 assert sys.version_info > (3, 5), 'Python 3 required to build docs'
@@ -43,9 +41,7 @@ def get_supported_pythons(classifiers):
 
 custom_sphinx_theme = try_import('alabaster')
 
-prj_dist = pkg_resources.get_distribution('cherrypy')
-prj_pkg_info = prj_dist.get_metadata(prj_dist.PKG_INFO)
-prj_meta = message_from_string(prj_pkg_info)
+prj_meta = importlib.metadata.metadata('cherrypy')
 prj_author = prj_meta['Author']
 prj_license = prj_meta['License']
 prj_description = prj_meta['Description']
@@ -54,7 +50,7 @@ prj_py_min_supported, prj_py_max_supported = map(
     lambda v: '.'.join(map(str, v)), prj_py_ver_range
 )
 
-project = prj_dist.project_name
+project = prj_meta['Name']
 
 github_url = 'https://github.com'
 github_repo_org = project.lower()

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ params = dict(
             'sphinxcontrib-apidoc>=0.3.0',
             'rst.linker>=1.11',
             'jaraco.packaging>=3.2',
-            'setuptools',
         ],
         'json': ['simplejson'],
         'routes_dispatcher': ['routes>=2.3.1'],


### PR DESCRIPTION
This patch replaces references to `pkg_resources` with `importlib.metadata`
The latest setuptools emits the following warning: `DeprecationWarning: pkg_resources is deprecated as an API`.

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [x] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [x] other



**What is the related issue number (starting with `#`)**
Fixes #1973 


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
