### PR TITLE
Drop dependency on obsolete setuptools_scm_git_archive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ requires = [
     "setuptools >= 45",
 
     # Plugins
-    "setuptools_scm[toml] >= 3.5",
-    "setuptools_scm_git_archive >= 1.1",
+    "setuptools_scm[toml] >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**

Fixes #2005

**What is the current behavior?** (You can also link to an open issue here)

CherryPy depends on obsoleted `setuptools_scm_git_archive`.

**What is the new behavior (if this is a feature change)?**

The build dependency are updated to require `setuptools_scm >= 7.0.0` and `setuptools_scm_git_archive` is no longer needed.  See also https://github.com/Changaco/setuptools_scm_git_archive/blob/master/README.rst

**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
