### PR TITLE
Replace deprecated `datetime.utcnow()` w/ a tz-aware variant

### DIFF
--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -452,6 +452,6 @@ class WSGIErrorHandler(logging.Handler):
 
 class LazyRfc3339UtcTime(object):
     def __str__(self):
-        """Return utcnow() in RFC3339 UTC Format."""
-        iso_formatted_now = datetime.datetime.utcnow().isoformat('T')
+        """Return datetime in RFC3339 UTC Format."""
+        iso_formatted_now = datetime.datetime.now(datetime.UTC).isoformat('T')
         return f'{iso_formatted_now!s}Z'

--- a/cherrypy/_cplogging.py
+++ b/cherrypy/_cplogging.py
@@ -453,5 +453,7 @@ class WSGIErrorHandler(logging.Handler):
 class LazyRfc3339UtcTime(object):
     def __str__(self):
         """Return datetime in RFC3339 UTC Format."""
-        iso_formatted_now = datetime.datetime.now(datetime.UTC).isoformat('T')
+        iso_formatted_now = datetime.datetime.now(
+            datetime.timezone.utc,
+        ).isoformat('T')
         return f'{iso_formatted_now!s}Z'

--- a/cherrypy/lib/locking.py
+++ b/cherrypy/lib/locking.py
@@ -19,10 +19,14 @@ class Timer(object):
         """
         Return a timer that will expire after `elapsed` passes.
         """
-        return cls(datetime.datetime.now(datetime.UTC) + elapsed)
+        return cls(
+            datetime.datetime.now(datetime.timezone.utc) + elapsed,
+        )
 
     def expired(self):
-        return datetime.datetime.now(datetime.UTC) >= self.expiration
+        return datetime.datetime.now(
+            datetime.timezone.utc,
+        ) >= self.expiration
 
 
 class LockTimeout(Exception):

--- a/cherrypy/lib/locking.py
+++ b/cherrypy/lib/locking.py
@@ -19,10 +19,10 @@ class Timer(object):
         """
         Return a timer that will expire after `elapsed` passes.
         """
-        return cls(datetime.datetime.utcnow() + elapsed)
+        return cls(datetime.datetime.now(datetime.UTC) + elapsed)
 
     def expired(self):
-        return datetime.datetime.utcnow() >= self.expiration
+        return datetime.datetime.now(datetime.UTC) >= self.expiration
 
 
 class LockTimeout(Exception):

--- a/cherrypy/test/sessiondemo.py
+++ b/cherrypy/test/sessiondemo.py
@@ -3,14 +3,7 @@
 
 import calendar
 from datetime import datetime
-
-try:
-    from datetime import UTC  # Python 3.11+
-except ImportError:
-    # Python 3.6-3.10
-    from datetime import timezone as _timezone
-    UTC = _timezone.utc
-    del _timezone
+from datetime import timezone as _timezone
 import sys
 
 import cherrypy
@@ -131,11 +124,11 @@ class Root(object):
             'reqcookie': cherrypy.request.cookie.output(),
             'sessiondata': list(cherrypy.session.items()),
             'servertime': (
-                datetime.now(UTC).strftime('%Y/%m/%d %H:%M UTC')
+                datetime.now(_timezone.utc).strftime('%Y/%m/%d %H:%M UTC')
             ),
             'serverunixtime':
             calendar.timegm(
-                datetime.utcnow(UTC).timetuple(),
+                datetime.utcnow(_timezone.utc).timetuple(),
             ),
             'cpversion': cherrypy.__version__,
             'pyversion': sys.version,

--- a/cherrypy/test/sessiondemo.py
+++ b/cherrypy/test/sessiondemo.py
@@ -127,7 +127,7 @@ class Root(object):
             ),
             'serverunixtime':
             calendar.timegm(
-                datetime.datetime.utcnow(UTC).timetuple()
+                datetime.utcnow(UTC).timetuple(),
             ),
             'cpversion': cherrypy.__version__,
             'pyversion': sys.version,

--- a/cherrypy/test/sessiondemo.py
+++ b/cherrypy/test/sessiondemo.py
@@ -2,7 +2,7 @@
 """A session demonstration app."""
 
 import calendar
-from datetime import datetime
+from datetime import datetime, UTC
 import sys
 
 import cherrypy
@@ -123,9 +123,12 @@ class Root(object):
             'reqcookie': cherrypy.request.cookie.output(),
             'sessiondata': list(cherrypy.session.items()),
             'servertime': (
-                datetime.utcnow().strftime('%Y/%m/%d %H:%M') + ' UTC'
+                datetime.now(UTC).strftime('%Y/%m/%d %H:%M UTC')
             ),
-            'serverunixtime': calendar.timegm(datetime.utcnow().timetuple()),
+            'serverunixtime':
+            calendar.timegm(
+                datetime.datetime.utcnow(UTC).timetuple()
+            ),
             'cpversion': cherrypy.__version__,
             'pyversion': sys.version,
             'expires': expires,

--- a/cherrypy/test/sessiondemo.py
+++ b/cherrypy/test/sessiondemo.py
@@ -2,7 +2,15 @@
 """A session demonstration app."""
 
 import calendar
-from datetime import datetime, UTC
+from datetime import datetime
+
+try:
+    from datetime import UTC  # Python 3.11+
+except ImportError:
+    # Python 3.6-3.10
+    from datetime import timezone as _timezone
+    UTC = _timezone.utc
+    del _timezone
 import sys
 
 import cherrypy

--- a/cherrypy/test/test_logging.py
+++ b/cherrypy/test/test_logging.py
@@ -216,7 +216,7 @@ def test_utc_in_timez(monkeypatch):
 
     class mock_datetime:
         @classmethod
-        def utcnow(cls):
+        def now(cls, tz):
             return utcoffset8_local_time_in_naive_utc
 
     monkeypatch.setattr('datetime.datetime', mock_datetime)


### PR DESCRIPTION
Calling `datetime.datetime.utcnow()` emits a deprecation warning now.
Python 3.12 reports:
```python-traceback
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```
This patch replaces it with a non-deprecated cross-python implementation.

**What kind of change does this PR introduce?**
  - [x] refactoring

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
