### PR TITLE
Upgrade the RTD config with the current schema

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,17 @@
 ---
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: >-
+      3.6
+
 python:
-  version: 3.6
-  extra_requirements:
-  - docs
-  - testing
-  pip_install: true
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs
+    - testing
 
 ...


### PR DESCRIPTION
The respective changes in the service have been announced in the following blog post: https://blog.readthedocs.com/migrate-configuration-v2/.