### PR TITLE
Use `os.listdir()` instead of `os.scandir()` in `FileSession` during clean-up

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -578,7 +578,8 @@ class FileSession(Session):
         """Clean up expired sessions."""
         now = self.now()
         # Iterate over all session files in self.storage_path
-        for fname in os.listdir(self.storage_path):
+        for entry in os.scandir(self.storage_path):
+            fname = entry.name
             have_session = (
                 fname.startswith(self.SESSION_PREFIX)
                 and not fname.endswith(self.LOCK_SUFFIX)
@@ -586,7 +587,7 @@ class FileSession(Session):
             if have_session:
                 # We have a session file: lock and load it and check
                 #   if it's expired. If it fails, nevermind.
-                path = os.path.join(self.storage_path, fname)
+                path = entry.path
                 self.acquire_lock(path)
                 if self.debug:
                     # This is a bit of a hack, since we're calling clean_up


### PR DESCRIPTION
`os.scandir()` is more effcient than `os.listdir()` and is generator based.

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [X] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**
when cleaning file-based session storage, `os.listdir()` returns a huge list of file names for very large session directories. so switching to `os.scandir()` function – a better and faster directory iterator should be beneficial.



**Other information**:


**Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
