### PR TITLE
Handle importlib-metadata fallback in docs/conf.py

### DIFF
--- a/cherrypy/__init__.py
+++ b/cherrypy/__init__.py
@@ -60,11 +60,8 @@ try:
     import importlib.metadata as importlib_metadata
 except ImportError:
     # fall back for python <= 3.7
-    # can simply pass when py 3.6/3.7 no longer supported
-    try:
-        import importlib_metadata
-    except ImportError:
-        pass
+    # This try/except can be removed with py <= 3.7 support
+    import importlib_metadata
 
 from threading import local as _local
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,13 @@
 import importlib
 import sys
 
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # fall back for python <= 3.7
+    # This try/except can be removed with py <= 3.7 support
+    import importlib_metadata
+
 assert sys.version_info > (3, 5), 'Python 3 required to build docs'
 
 
@@ -41,7 +48,7 @@ def get_supported_pythons(classifiers):
 
 custom_sphinx_theme = try_import('alabaster')
 
-prj_meta = importlib.metadata.metadata('cherrypy')
+prj_meta = importlib_metadata.metadata('cherrypy')
 prj_author = prj_meta['Author']
 prj_license = prj_meta['License']
 prj_description = prj_meta['Description']

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ params = dict(
         'more_itertools',
         'zc.lockfile',
         'jaraco.collections',
+        'importlib-metadata; python_version<="3.7"',
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
- also add install_requires for importlib-metadata

This is a followup pr to #1993

Missed handling fallback in py 3.6/3.7 and the install_requires for it.