### PR TITLE
Clean the session files upon unpackling Error in FileSession clean up

### DIFF
--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -603,6 +603,10 @@ class FileSession(Session):
                         if expiration_time < now:
                             # Session expired: deleting it
                             os.unlink(path)
+                
+                except pickle.UnpicklingError:
+                    os.unlink(path)
+                    
                 finally:
                     self.release_lock(path)
 

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -603,10 +603,10 @@ class FileSession(Session):
                         if expiration_time < now:
                             # Session expired: deleting it
                             os.unlink(path)
-                
+
                 except pickle.UnpicklingError:
                     os.unlink(path)
-                    
+
                 finally:
                     self.release_lock(path)
 


### PR DESCRIPTION
I've seen clean failures in my production error log files due to `UnpicklingError: invalid load key, '\x00'`. I suspect the session file was created by attackers.  This would 1) break the cleansing thread, leaving many expired sessions not cleaned up, also 2) I tend to think it's not good/safe to ignore and keep these "bad" session files. Below is the original traceback info in the error log.
```python-traceback
Traceback (most recent call last):
  File "C:\Program Files (x86)\Python311-32\Lib\site-packages\cherrypy\process\plugins.py", line 518, in run
    self.function(*self.args, **self.kwargs)
  File "C:\Program Files (x86)\Python311-32\Lib\site-packages\cherrypy\lib\sessions.py", line 586, in clean_up
    contents = self._load(path)
               ^^^^^^^^^^^^^^^^
  File "C:\Program Files (x86)\Python311-32\Lib\site-packages\cherrypy\lib\sessions.py", line 520, in _load
    return pickle.load(f)
           ^^^^^^^^^^^^^^
_pickle.UnpicklingError: invalid load key, '\x00'.
```
 

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [X] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)
`UnpicklingError: invalid load key, '\x00'` would break the cleansing thread, leaving many expired sessions not cleaned up, also I tend to think it's not good/safe to ignore and keep these "bad" session files.


**What is the new behavior (if this is a feature change)?**
If pickling a session file is throwing pickling error, then just delete that file.


**Other information**:


**Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
