### PR TITLE
🔧 Stop using the `cgi` stdlib module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v(next)
+-------
+
+* Removed the use of :mod:`cgi` deprecated in Python 3.11
+  -- by :user:`radez`.
+
 v18.9.0
 -------
 

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -21,43 +21,6 @@ and their .encode/.decode methods as needed.
 import http.client
 
 
-def _cgi_parseparam(s):
-    while s[:1] == ';':
-        s = s[1:]
-        end = s.find(';')
-        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
-            end = s.find(';', end + 1)
-        if end < 0:
-            end = len(s)
-        f = s[:end]
-        yield f.strip()
-        s = s[end:]
-
-
-def cgi_parse_header(line):
-    """Parse a Content-type like header.
-
-    Return the main content-type and a dictionary of options.
-
-    Copied from removed stdlib cgi module. Couldn't find
-    something to replace it with that provided same functionality
-    from the email module as suggested.
-    """
-    parts = _cgi_parseparam(';' + line)
-    key = parts.__next__()
-    pdict = {}
-    for p in parts:
-        i = p.find('=')
-        if i >= 0:
-            name = p[:i].strip().lower()
-            value = p[i + 1:].strip()
-            if len(value) >= 2 and value[0] == value[-1] == '"':
-                value = value[1:-1]
-                value = value.replace('\\\\', '\\').replace('\\"', '"')
-            pdict[name] = value
-    return key, pdict
-
-
 def ntob(n, encoding='ISO-8859-1'):
     """Return the given native string as a byte string in the given
     encoding.

--- a/cherrypy/_cpcompat.py
+++ b/cherrypy/_cpcompat.py
@@ -21,6 +21,43 @@ and their .encode/.decode methods as needed.
 import http.client
 
 
+def _cgi_parseparam(s):
+    while s[:1] == ';':
+        s = s[1:]
+        end = s.find(';')
+        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+            end = s.find(';', end + 1)
+        if end < 0:
+            end = len(s)
+        f = s[:end]
+        yield f.strip()
+        s = s[end:]
+
+
+def cgi_parse_header(line):
+    """Parse a Content-type like header.
+
+    Return the main content-type and a dictionary of options.
+
+    Copied from removed stdlib cgi module. Couldn't find
+    something to replace it with that provided same functionality
+    from the email module as suggested.
+    """
+    parts = _cgi_parseparam(';' + line)
+    key = parts.__next__()
+    pdict = {}
+    for p in parts:
+        i = p.find('=')
+        if i >= 0:
+            name = p[:i].strip().lower()
+            value = p[i + 1:].strip()
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+                value = value.replace('\\\\', '\\').replace('\\"', '"')
+            pdict[name] = value
+    return key, pdict
+
+
 def ntob(n, encoding='ISO-8859-1'):
     """Return the given native string as a byte string in the given
     encoding.

--- a/cherrypy/lib/covercp.py
+++ b/cherrypy/lib/covercp.py
@@ -22,7 +22,7 @@ it will call ``serve()`` for you.
 
 import re
 import sys
-import cgi
+import html
 import os
 import os.path
 import urllib.parse
@@ -352,9 +352,9 @@ class CoverStats(object):
                 buffer.append((lineno, line))
             if empty_the_buffer:
                 for lno, pastline in buffer:
-                    yield template % (lno, cgi.escape(pastline))
+                    yield template % (lno, html.escape(pastline))
                 buffer = []
-                yield template % (lineno, cgi.escape(line))
+                yield template % (lineno, html.escape(line))
 
     @cherrypy.expose
     def report(self, name):

--- a/cherrypy/lib/headers.py
+++ b/cherrypy/lib/headers.py
@@ -1,0 +1,38 @@
+"""headers."""
+
+
+def _parse_param(s):
+    while s[:1] == ';':
+        s = s[1:]
+        end = s.find(';')
+        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+            end = s.find(';', end + 1)
+        if end < 0:
+            end = len(s)
+        f = s[:end]
+        yield f.strip()
+        s = s[end:]
+
+
+def parse_header(line):
+    """Parse a Content-type like header.
+
+    Return the main content-type and a dictionary of options.
+
+    Copied from removed stdlib cgi module. Couldn't find
+    something to replace it with that provided same functionality
+    from the email module as suggested.
+    """
+    parts = _parse_param(';' + line)
+    key = parts.__next__()
+    pdict = {}
+    for p in parts:
+        i = p.find('=')
+        if i >= 0:
+            name = p[:i].strip().lower()
+            value = p[i + 1:].strip()
+            if len(value) >= 2 and value[0] == value[-1] == '"':
+                value = value[1:-1]
+                value = value.replace('\\\\', '\\').replace('\\"', '"')
+            pdict[name] = value
+    return key, pdict

--- a/cherrypy/lib/headers.py
+++ b/cherrypy/lib/headers.py
@@ -19,9 +19,10 @@ def parse_header(line):
 
     Return the main content-type and a dictionary of options.
 
-    Copied from removed stdlib cgi module. Couldn't find
-    something to replace it with that provided same functionality
-    from the email module as suggested.
+    Copied from removed stdlib cgi module. See
+    `cherrypy/cherrypy#2014 (comment)
+    <https://github.com/cherrypy/cherrypy/issues/2014#issuecomment-1883774891>`_
+    for background.
     """
     parts = _parse_param(';' + line)
     key = parts.__next__()

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -12,7 +12,6 @@ import email.utils
 import re
 import builtins
 from binascii import b2a_base64
-from cherrypy._cpcompat import cgi_parse_header as parse_header
 from email.header import decode_header
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import unquote_plus
@@ -21,6 +20,7 @@ import jaraco.collections
 
 import cherrypy
 from cherrypy._cpcompat import ntob, ntou
+from .headers import parse_header
 
 response_codes = BaseHTTPRequestHandler.responses.copy()
 

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -12,7 +12,7 @@ import email.utils
 import re
 import builtins
 from binascii import b2a_base64
-from cgi import parse_header
+from cherrypy._cpcompat import cgi_parse_header as parse_header
 from email.header import decode_header
 from http.server import BaseHTTPRequestHandler
 from urllib.parse import unquote_plus

--- a/pytest.ini
+++ b/pytest.ini
@@ -59,9 +59,6 @@ filterwarnings =
   ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning
   ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:PendingDeprecationWarning
 
-  # TODO: Replace the use of `cgi`. It seems untrivial.
-  ignore:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning
-
   # TODO: Remove once `cheroot.webtest._open_url_once` is fixed to release
   # TODO: connection properly.
   ignore:unclosed <socket.socket fd=:ResourceWarning


### PR DESCRIPTION
the module was deprecatied in py 3.11 and removed in py 3.13 there are examples of using the email module to resolve this: PEP 594
https://github.com/python-babel/babel/issues/873
https://stackoverflow.com/questions/69068527/python-3-cgi-parse-header

This method doesn't seem to work for cherrypy.
The email.message module is trying to create a higher level object that is intelligent about the headers it has defined. The cgi.parse_header function is a very low level unintelligent function that simply parses header content based on structure and does not inspect the contents. Because of the intelligence of the email.message object cherrypy can't use it in the very generic way that the cgi.parse_header function was being used.

Fix #2014

**What kind of change does this PR introduce?**
  - [x] refactoring
  - [x] other - debt



**What is the related issue number (starting with `#`)**
#2014


**What is the current behavior?** (You can also link to an open issue here)
Deprecation warnings in 3.11 & and 3.12
Module import error in 3.13
#2014 

**What is the new behavior (if this is a feature change)?**



**Other information**:


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
