### PR TITLE
Replace `distutils.spawn.find_executable()` with `shutil.which()` in tests

### DIFF
--- a/cherrypy/test/test_session.py
+++ b/cherrypy/test/test_session.py
@@ -4,7 +4,7 @@ import threading
 import time
 from http.client import HTTPConnection
 
-from distutils.spawn import find_executable
+from shutil import which
 import pytest
 from path import Path
 from more_itertools import consume
@@ -407,7 +407,7 @@ class SessionTest(helper.CPWebCase):
 
 
 def is_memcached_present():
-    executable = find_executable('memcached')
+    executable = which('memcached')
     return bool(executable)
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**



**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**
No changes


**Other information**:
The package distutils is deprecated and slated for removal in Python 3.12.

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
