### PR TITLE
Add test coverage for `HeaderElement` and `AcceptElement`

### DIFF
--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -85,8 +85,12 @@ def test_invalid_status(status_code, error_msg):
 @pytest.mark.parametrize(
     ('header_content', 'value', 'params'),
     (
-        ('application/x-www-form-urlencoded',
-         'application/x-www-form-urlencoded', {}),  # default_content_type
+        pytest.param(
+            'application/x-www-form-urlencoded',
+            'application/x-www-form-urlencoded',
+            {},
+            id='default-content-type',
+        ),
         ('application/json;charset="utf8"',
          'application/json', {'charset': 'utf8'}),
         ('audio/*; q=0.2, audio/basic',
@@ -121,8 +125,12 @@ def test_header_element(header_content, value, params):
 @pytest.mark.parametrize(
     ('header_content', 'media_type', 'qvalue'),
     (
-        ('application/x-www-form-urlencoded',
-         'application/x-www-form-urlencoded', 1.0),  # default_content_type
+        pytest.param(
+            'application/x-www-form-urlencoded',
+            'application/x-www-form-urlencoded',
+            1.0,
+            id='default-content-type',
+        ),
         ('application/json;charset="utf8"',
          'application/json', 1.0),
         ('text/*, text/html, text/html;level=1, */*',

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -84,7 +84,7 @@ def test_invalid_status(status_code, error_msg):
 
 @pytest.mark.parametrize(
     ('header_content', 'value', 'params'),
-    [
+    (
         ('application/x-www-form-urlencoded',
          'application/x-www-form-urlencoded', {}),  # default_content_type
         ('application/json;charset="utf8"',
@@ -105,7 +105,7 @@ def test_invalid_status(status_code, error_msg):
          'text/plain', {}),
         ('text/xml',
          'text/xml', {}),
-    ]
+    ),
 )
 def test_header_element(header_content, value, params):
     """Test that ``value`` and ``params`` are extracted from headers.
@@ -120,7 +120,7 @@ def test_header_element(header_content, value, params):
 
 @pytest.mark.parametrize(
     ('header_content', 'media_type', 'qvalue'),
-    [
+    (
         ('application/x-www-form-urlencoded',
          'application/x-www-form-urlencoded', 1.0),  # default_content_type
         ('application/json;charset="utf8"',
@@ -133,7 +133,7 @@ def test_header_element(header_content, value, params):
          'text/plain', 1.0),
         ('text/xml',
          'text/xml', 1.0),
-    ]
+    ),
 )
 def test_accept_element(header_content, media_type, qvalue):
    """Test that ``value`` and ``qvalue`` are extracted from headers.
@@ -147,7 +147,7 @@ def test_accept_element(header_content, media_type, qvalue):
 
 @pytest.mark.parametrize(
     ('header_content', 'media_type', 'qvalue'),
-    [
+    (
         ('audio/*; q=0.2, audio/basic',
          'audio/*', {'q': '0.2, audio/basic'}),
         ('text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c',
@@ -156,7 +156,7 @@ def test_accept_element(header_content, media_type, qvalue):
          'gzip', {'q': '0'}),
         ('da, en-gb;q=0.8, en;q=0.7',
          'da, en-gb', 0.8),
-    ]
+    ),
 )
 def test_accept_element_raises_400(header_content, media_type, qvalue):
     """Check bad headers crash :class:`cherrypy.httputil.AcceptElement`.

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -116,8 +116,7 @@ def test_header_element(header_content, value, params):
     """
     hdr_elem = httputil.HeaderElement.from_str(header_content)
 
-    assert hdr_elem.value == value
-    assert hdr_elem.params == params
+    assert (hdr_elem.value, hdr_elem.params) == (value, params)
 
 
 @pytest.mark.parametrize(
@@ -144,8 +143,7 @@ def test_accept_element(header_content, media_type, qvalue):
    :py:class:`~cherrypy.httputil.AcceptElement` class.
    """
     acc_elem = httputil.AcceptElement.from_str(header_content)
-    assert acc_elem.value == media_type
-    assert acc_elem.qvalue == qvalue
+    assert (acc_elem.value, acc_elem.qvalue) == (media_type, qvalue)
 
 
 @pytest.mark.parametrize(

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -108,10 +108,12 @@ def test_invalid_status(status_code, error_msg):
     ]
 )
 def test_header_element(header_content, value, params):
-    """ Test that value and params are parsed from headers.
+    """Test that ``value`` and ``params`` are extracted from headers.
 
-        Testing that the value and params are parsed from
-        headers passed to HeaderElement from httputils """
+    This is a positive test case, checking that the value and
+    params are parsed from headers that are being passed into
+    the :py:class:`~cherrypy.httputil.HeaderElement` class.
+    """
     hdr_elem = httputil.HeaderElement.from_str(header_content)
 
     assert hdr_elem.value == value
@@ -136,8 +138,11 @@ def test_header_element(header_content, value, params):
     ]
 )
 def test_accept_element(header_content, media_type, qvalue):
-    """ Test that value and qvalue are parsed from headers passed to
-        AcceptElement from httputils """
+   """Test that ``value`` and ``qvalue`` are extracted from headers.
+
+   This is being checked in the context of the
+   :py:class:`~cherrypy.httputil.AcceptElement` class.
+   """
     acc_elem = httputil.AcceptElement.from_str(header_content)
     assert acc_elem.value == media_type
     assert acc_elem.qvalue == qvalue
@@ -157,7 +162,9 @@ def test_accept_element(header_content, media_type, qvalue):
     ]
 )
 def test_accept_element_raises_400(header_content, media_type, qvalue):
-    """ Test that headers passed to AcceptElement from httputils
-        raise an expected HTTPError """
+    """Check bad headers crash :class:`cherrypy.httputil.AcceptElement`.
+
+    The expected exception is :exc:`~cherrypy.HTTPError`.
+    """
     httputil.AcceptElement.from_str(header_content)
     assert pytest.raises(cherrypy.HTTPError)

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -120,7 +120,7 @@ def test_header_element(header_content, value, params):
 
 
 @pytest.mark.parametrize(
-    'header_content,media_type,qvalue',
+    ('header_content', 'media_type', 'qvalue'),
     [
         ('application/x-www-form-urlencoded',
          'application/x-www-form-urlencoded', 1.0),  # default_content_type
@@ -147,7 +147,7 @@ def test_accept_element(header_content, media_type, qvalue):
 
 
 @pytest.mark.parametrize(
-    'header_content,media_type,qvalue',
+    ('header_content', 'media_type', 'qvalue'),
     [
         ('audio/*; q=0.2, audio/basic',
          'audio/*', {'q': '0.2, audio/basic'}),

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -144,11 +144,11 @@ def test_header_element(header_content, value, params):
     ),
 )
 def test_accept_element(header_content, media_type, qvalue):
-   """Test that ``value`` and ``qvalue`` are extracted from headers.
+    """Test that ``value`` and ``qvalue`` are extracted from headers.
 
-   This is being checked in the context of the
-   :py:class:`~cherrypy.httputil.AcceptElement` class.
-   """
+    This is being checked in the context of the
+    :py:class:`~cherrypy.httputil.AcceptElement` class.
+    """
     acc_elem = httputil.AcceptElement.from_str(header_content)
     assert (acc_elem.value, acc_elem.qvalue) == (media_type, qvalue)
 

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -115,7 +115,6 @@ def test_header_element(header_content, value, params):
     the :py:class:`~cherrypy.httputil.HeaderElement` class.
     """
     hdr_elem = httputil.HeaderElement.from_str(header_content)
-
     assert (hdr_elem.value, hdr_elem.params) == (value, params)
 
 

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -171,5 +171,8 @@ def test_accept_element_raises_400(header_content, media_type, qvalue):
 
     The expected exception is :exc:`~cherrypy.HTTPError`.
     """
-    httputil.AcceptElement.from_str(header_content)
-    assert pytest.raises(cherrypy.HTTPError)
+    with pytest.raises(
+            cherrypy.HTTPError,
+            match=r'^Malformed HTTP header: `[^`]+`$',
+    ):
+        httputil.AcceptElement.from_str(header_content)

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -1,4 +1,5 @@
 """Test helpers from ``cherrypy.lib.httputil`` module."""
+import cherrypy
 import pytest
 import http.client
 
@@ -79,3 +80,84 @@ def test_invalid_status(status_code, error_msg):
     """Check that invalid status cause certain errors."""
     with pytest.raises(ValueError, match=error_msg):
         httputil.valid_status(status_code)
+
+
+@pytest.mark.parametrize(
+    ('header_content', 'value', 'params'),
+    [
+        ('application/x-www-form-urlencoded',
+         'application/x-www-form-urlencoded', {}),  # default_content_type
+        ('application/json;charset="utf8"',
+         'application/json', {'charset': 'utf8'}),
+        ('audio/*; q=0.2, audio/basic',
+         'audio/*', {'q': '0.2, audio/basic'}),
+        ('text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c',
+         'text/plain', {'q': '0.8, text/x-c'}),
+        ('text/*, text/html, text/html;level=1, */*',
+         'text/*, text/html, text/html', {'level': '1, */*'}),
+        ('iso-8859-5, unicode-1-1;q=0.8',
+         'iso-8859-5, unicode-1-1', {'q': '0.8'}),
+        ('gzip;q=1.0, identity; q=0.5, *;q=0',
+         'gzip', {'q': '0'}),
+        ('da, en-gb;q=0.8, en;q=0.7',
+         'da, en-gb', {'q': '0.7'}),
+        ('text/plain',
+         'text/plain', {}),
+        ('text/xml',
+         'text/xml', {}),
+    ]
+)
+def test_header_element(header_content, value, params):
+    """ Test that value and params are parsed from headers.
+
+        Testing that the value and params are parsed from
+        headers passed to HeaderElement from httputils """
+    hdr_elem = httputil.HeaderElement.from_str(header_content)
+
+    assert hdr_elem.value == value
+    assert hdr_elem.params == params
+
+
+@pytest.mark.parametrize(
+    'header_content,media_type,qvalue',
+    [
+        ('application/x-www-form-urlencoded',
+         'application/x-www-form-urlencoded', 1.0),  # default_content_type
+        ('application/json;charset="utf8"',
+         'application/json', 1.0),
+        ('text/*, text/html, text/html;level=1, */*',
+         'text/*, text/html, text/html', 1.0),
+        ('iso-8859-5, unicode-1-1;q=0.8',
+         'iso-8859-5, unicode-1-1', 0.8),
+        ('text/plain',
+         'text/plain', 1.0),
+        ('text/xml',
+         'text/xml', 1.0),
+    ]
+)
+def test_accept_element(header_content, media_type, qvalue):
+    """ Test that value and qvalue are parsed from headers passed to
+        AcceptElement from httputils """
+    acc_elem = httputil.AcceptElement.from_str(header_content)
+    assert acc_elem.value == media_type
+    assert acc_elem.qvalue == qvalue
+
+
+@pytest.mark.parametrize(
+    'header_content,media_type,qvalue',
+    [
+        ('audio/*; q=0.2, audio/basic',
+         'audio/*', {'q': '0.2, audio/basic'}),
+        ('text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c',
+         'text/plain', {'q': '0.8, text/x-c'}),
+        ('gzip;q=1.0, identity; q=0.5, *;q=0',
+         'gzip', {'q': '0'}),
+        ('da, en-gb;q=0.8, en;q=0.7',
+         'da, en-gb', 0.8),
+    ]
+)
+def test_accept_element_raises_400(header_content, media_type, qvalue):
+    """ Test that headers passed to AcceptElement from httputils
+        raise an expected HTTPError """
+    httputil.AcceptElement.from_str(header_content)
+    assert pytest.raises(cherrypy.HTTPError)


### PR DESCRIPTION
This is in preparation for issue #2014
Establishing tests to validate these objects so we can pull in the deprecated cgi.parse_header code

**What kind of change does this PR introduce?**
  - [x] tests/coverage improvement
