### PR TITLE
Add support for Cythonized API Classes 

### DIFF
--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -137,7 +137,6 @@ def popargs(*args, **kwargs):
         class Root:
             def index(self):
                 #...
-
     """
     # Since keyword arg comes after *args, we have to process it ourselves
     # for lower versions of python.
@@ -201,16 +200,17 @@ def url(path='', qs='', script_name=None, base=None, relative=None):
     If it does not start with a slash, this returns
         (base + script_name [+ request.path_info] + path + qs).
 
-    If script_name is None, cherrypy.request will be used
-    to find a script_name, if available.
+    If script_name is None, cherrypy.request will be used to find a
+    script_name, if available.
 
     If base is None, cherrypy.request.base will be used (if available).
     Note that you can use cherrypy.tools.proxy to change this.
 
-    Finally, note that this function can be used to obtain an absolute URL
-    for the current request path (minus the querystring) by passing no args.
-    If you call url(qs=cherrypy.request.query_string), you should get the
-    original browser URL (assuming no internal redirections).
+    Finally, note that this function can be used to obtain an absolute
+    URL for the current request path (minus the querystring) by passing
+    no args. If you call url(qs=cherrypy.request.query_string), you
+    should get the original browser URL (assuming no internal
+    redirections).
 
     If relative is None or not provided, request.app.relative_urls will
     be used (if available, else False). If False, the output will be an
@@ -320,8 +320,8 @@ def normalize_path(path):
 class _ClassPropertyDescriptor(object):
     """Descript for read-only class-based property.
 
-    Turns a classmethod-decorated func into a read-only property of that class
-    type (means the value cannot be set).
+    Turns a classmethod-decorated func into a read-only property of that
+    class type (means the value cannot be set).
     """
 
     def __init__(self, fget, fset=None):

--- a/cherrypy/_helper.py
+++ b/cherrypy/_helper.py
@@ -25,7 +25,7 @@ def expose(func=None, alias=None):
     import sys
     import types
     decoratable_types = types.FunctionType, types.MethodType, type,
-    if isinstance(func, decoratable_types):
+    if isinstance(func, decoratable_types) or hasattr(func, 'func_code'):
         if alias is None:
             # @expose
             func.exposed = True
@@ -137,6 +137,7 @@ def popargs(*args, **kwargs):
         class Root:
             def index(self):
                 #...
+
     """
     # Since keyword arg comes after *args, we have to process it ourselves
     # for lower versions of python.
@@ -200,17 +201,16 @@ def url(path='', qs='', script_name=None, base=None, relative=None):
     If it does not start with a slash, this returns
         (base + script_name [+ request.path_info] + path + qs).
 
-    If script_name is None, cherrypy.request will be used to find a
-    script_name, if available.
+    If script_name is None, cherrypy.request will be used
+    to find a script_name, if available.
 
     If base is None, cherrypy.request.base will be used (if available).
     Note that you can use cherrypy.tools.proxy to change this.
 
-    Finally, note that this function can be used to obtain an absolute
-    URL for the current request path (minus the querystring) by passing
-    no args. If you call url(qs=cherrypy.request.query_string), you
-    should get the original browser URL (assuming no internal
-    redirections).
+    Finally, note that this function can be used to obtain an absolute URL
+    for the current request path (minus the querystring) by passing no args.
+    If you call url(qs=cherrypy.request.query_string), you should get the
+    original browser URL (assuming no internal redirections).
 
     If relative is None or not provided, request.app.relative_urls will
     be used (if available, else False). If False, the output will be an
@@ -320,8 +320,8 @@ def normalize_path(path):
 class _ClassPropertyDescriptor(object):
     """Descript for read-only class-based property.
 
-    Turns a classmethod-decorated func into a read-only property of that
-    class type (means the value cannot be set).
+    Turns a classmethod-decorated func into a read-only property of that class
+    type (means the value cannot be set).
     """
 
     def __init__(self, fget, fset=None):


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [x] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
[#1814](https://github.com/cherrypy/cherrypy/issues/1814)


**What is the current behavior?** (You can also link to an open issue here)
Currently, when an API class is cythonized, the methods for the class do not pass the decoratable_types check. The issue [#1814](https://github.com/cherrypy/cherrypy/issues/1814) was raised 5 years ago and is still relevant.


**What is the new behavior (if this is a feature change)?**
Cythonized API class methods are getting mounted in cherrypy.tree and the API runs successfully.


**Other information**:
I tried the approach suggested by @webknjaz to put the types.BuiltinFunctionType in the decoratable_types, however, not all cythonized methods are of types.BuiltinFunctionType. The one thing these functions have in common is the "func_code" attribute.

As for the testing of this change, I am still looking into it. Currently, I can only come up with one way where I create a .whl file and install the cythonized API as a package, then import from the package and test if CherryPy is working, but this way does not seem very efficient. 

At worst, the hasattr check may fail in later python versions (very unlikely since func_code is a core cython method attribute). This feature is important for people who want to speedup and package their code using Cython.


**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
