### PR TITLE
Update GHA sdist name to lowercase for new setuptools

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -336,7 +336,7 @@ jobs:
                 mode=FILE_APPEND_MODE,
         ) as outputs_file:
             print(
-                "sdist=${{ steps.dist.outputs.name }}-${{
+                "sdist=cherrypy-${{
                     steps.request-check.outputs.release-requested == 'true'
                     && github.event.inputs.release-version
                     || steps.scm-version.outputs.dist-version


### PR DESCRIPTION
CI fails because with the setuptools upgrade, the sdist names started being lowercase. The CI declaration needs to be fixed to expect a new name