### PR TITLE
Replace zc.lockfile with filelock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ params = dict(
         'cheroot>=8.2.1',
         'portend>=2.1.1',
         'more_itertools',
-        'zc.lockfile',
+        'filelock',
         'jaraco.collections',
         'importlib-metadata; python_version<="3.7"',
     ],


### PR DESCRIPTION
Hey there, Arch Linux maintainer here 👋

Our  [cherrypy package](https://archlinux.org/packages/extra/any/python-cherrypy/) is currently one of only two packages depending on the orphaned [zc.lockfile package](https://archlinux.org/packages/extra/any/python-zc.lockfile/) in the Arch Linux repositories. Migrating to  [filelock](https://github.com/tox-dev/filelock) would allow us to eventually drop `zc.lockfile` entirely from our repos, reducing the maintenance workload.

We might decide to patch this in anyways, since it was fairly non-intrusive, but I'd thought I'd check if we could upstream it first. Cheers!