### PR TITLE
Tests: don't use an ephemeral port

### DIFF
--- a/cherrypy/test/benchmark.py
+++ b/cherrypy/test/benchmark.py
@@ -7,8 +7,8 @@ Usage:
 --notests:     start the server but do not run the tests; this allows
                you to check the tested pages with a browser
 --help:        show this help message
---cpmodpy:     run tests via apache on 54583 (with the builtin _cpmodpy)
---modpython:   run tests via apache on 54583 (with modpython_gateway)
+--cpmodpy:     run tests via apache on 24583 (with the builtin _cpmodpy)
+--modpython:   run tests via apache on 24583 (with modpython_gateway)
 --ab=path:     Use the ab script/executable at 'path' (see below)
 --apache=path: Use the apache script/exe at 'path' (see below)
 
@@ -87,7 +87,7 @@ def init():
         'log.error.file': '',
         'environment': 'production',
         'server.socket_host': '127.0.0.1',
-        'server.socket_port': 54583,
+        'server.socket_port': 24583,
         'server.max_request_header_size': 0,
         'server.max_request_body_size': 0,
     })
@@ -159,7 +159,7 @@ class ABSession:
 
     Server Software:        CherryPy/3.1beta
     Server Hostname:        127.0.0.1
-    Server Port:            54583
+    Server Port:            24583
 
     Document Path:          /static/index.html
     Document Length:        14 bytes
@@ -353,12 +353,12 @@ def run_modpython(use_wsgi=False):
         pyopts.append(
             ('wsgi.startup', 'cherrypy.test.benchmark::startup_modpython'))
         handler = 'modpython_gateway::handler'
-        s = s(port=54583, opts=pyopts,
+        s = s(port=24583, opts=pyopts,
               apache_path=APACHE_PATH, handler=handler)
     else:
         pyopts.append(
             ('cherrypy.setup', 'cherrypy.test.benchmark::startup_modpython'))
-        s = s(port=54583, opts=pyopts, apache_path=APACHE_PATH)
+        s = s(port=24583, opts=pyopts, apache_path=APACHE_PATH)
 
     try:
         s.start()

--- a/cherrypy/test/helper.py
+++ b/cherrypy/test/helper.py
@@ -252,7 +252,7 @@ class CPWebCase(webtest.WebCase):
         conf = {
             'scheme': 'http',
             'protocol': 'HTTP/1.1',
-            'port': 54583,
+            'port': 24583,
             'host': '127.0.0.1',
             'validate': False,
             'server': 'wsgi',

--- a/cherrypy/test/test_mime.py
+++ b/cherrypy/test/test_mime.py
@@ -102,7 +102,7 @@ class SafeMultipartHandlingTest(helper.CPWebCase):
             ('Content-Type', 'multipart/form-data; '
              'boundary=----------KM7Ij5cH2KM7Ef1gL6ae0ae0cH2gL6'),
             ('User-Agent', 'Shockwave Flash'),
-            ('Host', 'www.example.com:54583'),
+            ('Host', 'www.example.com:24583'),
             ('Content-Length', '499'),
             ('Connection', 'Keep-Alive'),
             ('Cache-Control', 'no-cache'),


### PR DESCRIPTION
Ports >= 32768 may already be [in use for outgoing TCP connections](https://en.wikipedia.org/wiki/Ephemeral_port), so we must use a lower port number here.

**What kind of change does this PR introduce?**
  - [x] bug fix
  - [x] tests/coverage improvement

**What is the related issue number (starting with `#`)**
None, as far as I know

**What is the current behavior?** (You can also link to an open issue here)
Tests sometimes randomly fail, if port 54583 is already used.

**What is the new behavior (if this is a feature change)?**
Tests only fail if port 24583 is in use. This is not a standard port number so failure is unlikely.

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
