### PR TITLE
🧪 Drop support for EOL Pythons below 3.9

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,6 @@ env:
   PROJECT_NAME: cherrypy
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
-  PYTHONLEGACYWINDOWSSTDIO: 1  # Python 3.6 hack
   PYTHONUTF8: 1
   TOX_PARALLEL_NO_SPINNER: 1  # Disable tox's parallel run spinner animation
   TOX_TESTENV_PASSENV: >-  # Make tox-wrapped tools see color requests
@@ -579,10 +578,6 @@ jobs:
         - >-
           3.10
         - 3.9
-        - 3.8
-        - 3.7
-        - 3.6
-        - pypy-3.6
         - ~3.12.0-0
         runner-vm-os:
         - ubuntu-24.04
@@ -592,14 +587,7 @@ jobs:
         - macos-13
         - windows-2019
         exclude:
-        # NOTE: Windows PyPy jobs are excluded to address the tox bug
-        # NOTE: https://github.com/tox-dev/tox/issues/1704.
-        # NOTE: They should be re-added once it's fixed.
-        - runner-vm-os: windows-2022
-          python-version: pypy-3.6
-        - runner-vm-os: windows-2019
-          python-version: pypy-3.6
-        # NOTE: Windows PyPy 3.7 jobs are excluded because of the lack
+        # NOTE: Windows PyPy 3.9 jobs are excluded because of the lack
         # NOTE: of the build deps to compile cryptography.
         # NOTE: They should be re-added once it's fixed.
         - runner-vm-os: windows-2022
@@ -609,18 +597,10 @@ jobs:
         # NOTE: macOS PyPy jobs are excluded because installing cryptography
         # NOTE: needs openssl headers that aren't present at the moment.
         # TODO: Remove the exclusions once this is addressed.
-        - runner-vm-os: macos-15
-          python-version: pypy-3.6
         - runner-vm-os: macos-11
           python-version: pypy-3.9
         - runner-vm-os: macos-12
           python-version: pypy-3.9
-        - runner-vm-os: ubuntu-22.04
-          python-version: 3.6  # EOL, only provided for older OSs
-        - runner-vm-os: macos-15
-          python-version: 3.6  # EOL, only provided for older OSs
-        - runner-vm-os: macos-15
-          python-version: 3.7  # EOL, only provided for older OSs
         include: []  # TODO: include TOXENV=cheroot-master
 
     continue-on-error: >-
@@ -670,16 +650,6 @@ jobs:
         pip install
         --user
         '${{ env.TOX_VERSION }}'
-
-    - name: Patch tox.ini for Python 3.6 under Windows
-      if: >-
-        runner.os == 'Windows'
-        && matrix.python-version == '3.6'
-      run: >-
-        sed -i
-        's/^package_env\(\s\)\?=.*/package_env = py36-win-dummy/g'
-        tox.ini
-      shell: bash
 
     - name: Download all the dists
       uses: actions/download-artifact@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 v(next)
 -------
 
+* Dropped support for Python 3.6, 3.7 and 3.8
+  -- by :user:`webknjaz`.
+
 * Deprecated the accidentally exposed ``cherrypy.lib.headers``
   -- by :user:`webknjaz`.
 

--- a/cherrypy/__init__.py
+++ b/cherrypy/__init__.py
@@ -56,12 +56,7 @@ These API's are described in the `CherryPy specification
 <https://github.com/cherrypy/cherrypy/wiki/CherryPySpec>`_.
 """
 
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # fall back for python <= 3.7
-    # This try/except can be removed with py <= 3.7 support
-    import importlib_metadata
+import importlib.metadata as importlib_metadata
 
 from threading import local as _local
 

--- a/cherrypy/_cpconfig.py
+++ b/cherrypy/_cpconfig.py
@@ -113,8 +113,7 @@ config, and only when you use cherrypy.config.update.
 You can define your own namespaces to be called at the Global, Application,
 or Request level, by adding a named handler to cherrypy.config.namespaces,
 app.namespaces, or app.request_class.namespaces. The name can
-be any string, and the handler must be either a callable or a (Python 2.5
-style) context manager.
+be any string, and the handler must be either a callable or a context manager.
 """
 
 import cherrypy

--- a/cherrypy/lib/profiler.py
+++ b/cherrypy/lib/profiler.py
@@ -105,23 +105,10 @@ class Profiler(object):
         :rtype: str
         """
         sio = io.StringIO()
-        if sys.version_info >= (2, 5):
-            s = pstats.Stats(os.path.join(self.path, filename), stream=sio)
-            s.strip_dirs()
-            s.sort_stats(sortby)
-            s.print_stats()
-        else:
-            # pstats.Stats before Python 2.5 didn't take a 'stream' arg,
-            # but just printed to stdout. So re-route stdout.
-            s = pstats.Stats(os.path.join(self.path, filename))
-            s.strip_dirs()
-            s.sort_stats(sortby)
-            oldout = sys.stdout
-            try:
-                sys.stdout = sio
-                s.print_stats()
-            finally:
-                sys.stdout = oldout
+        s = pstats.Stats(os.path.join(self.path, filename), stream=sio)
+        s.strip_dirs()
+        s.sort_stats(sortby)
+        s.print_stats()
         response = sio.getvalue()
         sio.close()
         return response

--- a/cherrypy/lib/reprconf.py
+++ b/cherrypy/lib/reprconf.py
@@ -242,8 +242,8 @@ class _Builder:
     def build_Index(self, o):
         return self.build(o.value)
 
-    def _build_call35(self, o):
-        """Emulate ``build_Call`` under Python 3.5."""
+    def build_Call(self, o):
+        """Emulate ``build_Call`` under Python 3.5+."""
         # Workaround for python 3.5. _ast.Call signature, docs found at
         # https://greentreesnakes.readthedocs.org/en/latest/nodes.html
         import ast
@@ -269,32 +269,6 @@ class _Builder:
             else:  # defined on the call as: arg=value
                 kwargs[kw.arg] = self.build(kw.value)
         return callee(*args, **kwargs)
-
-    def build_Call(self, o):
-        if sys.version_info >= (3, 5):
-            return self._build_call35(o)
-
-        callee = self.build(o.func)
-
-        if o.args is None:
-            args = ()
-        else:
-            args = tuple([self.build(a) for a in o.args])
-
-        if o.starargs is None:
-            starargs = ()
-        else:
-            starargs = tuple(self.build(o.starargs))
-
-        if o.kwargs is None:
-            kwargs = {}
-        else:
-            kwargs = self.build(o.kwargs)
-        if o.keywords is not None:  # direct a=b keywords
-            for kw in o.keywords:
-                # preference because is a direct keyword against **kwargs
-                kwargs[kw.arg] = self.build(kw.value)
-        return callee(*(args + starargs), **kwargs)
 
     def build_List(self, o):
         return list(map(self.build, o.elts))
@@ -335,10 +309,8 @@ class _Builder:
 
         raise TypeError('unrepr could not resolve the name %s' % repr(name))
 
-    def build_NameConstant(self, o):
+    def build_Constant(self, o):
         return o.value
-
-    build_Constant = build_NameConstant  # Python 3.8 change
 
     def build_UnaryOp(self, o):
         op, operand = map(self.build, [o.op, o.operand])

--- a/cherrypy/test/test_http.py
+++ b/cherrypy/test/test_http.py
@@ -145,15 +145,12 @@ class HTTPTests(helper.CPWebCase):
         else:
             c = HTTPConnection('%s:%s' % (self.interface(), self.PORT))
 
-        # `_get_content_length` is needed for Python 3.6+
         with mock.patch.object(
                 c,
                 '_get_content_length',
                 lambda body, method: None,
                 create=True):
-            # `_set_content_length` is needed for Python 2.7-3.5
-            with mock.patch.object(c, '_set_content_length', create=True):
-                c.request('POST', '/')
+            c.request('POST', '/')
 
         response = c.getresponse()
         self.body = response.fp.read()
@@ -235,12 +232,7 @@ class HTTPTests(helper.CPWebCase):
         c = self.make_connection()
         c._output(b'geT /')
         c._send_output()
-        if hasattr(c, 'strict'):
-            response = c.response_class(c.sock, strict=c.strict, method='GET')
-        else:
-            # Python 3.2 removed the 'strict' feature, saying:
-            # "http.client now always assumes HTTP/1.x compliant servers."
-            response = c.response_class(c.sock, method='GET')
+        response = c.response_class(c.sock, method='GET')
         response.begin()
         self.assertEqual(response.status, 400)
         self.assertEqual(response.fp.read(22), b'Malformed Request-Line')

--- a/cherrypy/test/test_session.py
+++ b/cherrypy/test/test_session.py
@@ -146,10 +146,7 @@ class SessionTest(helper.CPWebCase):
     def teardown_class(cls):
         """Clean up sessions."""
         super(cls, cls).teardown_class()
-        try:
-            files_to_clean = localDir.iterdir()  # Python 3.8+
-        except AttributeError:
-            files_to_clean = localDir.listdir()  # Python 3.6-3.7
+        files_to_clean = localDir.iterdir()
 
         consume(
             file.remove_p()

--- a/cherrypy/test/test_tools.py
+++ b/cherrypy/test/test_tools.py
@@ -2,7 +2,6 @@
 
 import gzip
 import io
-import sys
 import time
 import types
 import unittest
@@ -13,16 +12,6 @@ import cherrypy
 from cherrypy import tools
 from cherrypy._cpcompat import ntou
 from cherrypy.test import helper, _test_decorators
-
-
-*PY_VER_MINOR, _ = PY_VER_PATCH = sys.version_info[:3]
-# Refs:
-# bugs.python.org/issue39389
-# docs.python.org/3.7/whatsnew/changelog.html#python-3-7-7-release-candidate-1
-# docs.python.org/3.8/whatsnew/changelog.html#python-3-8-2-release-candidate-1
-HAS_GZIP_COMPRESSION_HEADER_FIXED = PY_VER_PATCH >= (3, 8, 2) or (
-    PY_VER_MINOR == (3, 7) and PY_VER_PATCH >= (3, 7, 7)
-)
 
 
 timeout = 0.2
@@ -367,13 +356,6 @@ class ToolTests(helper.CPWebCase):
                          ('Accept-Charset', 'ISO-8859-1,utf-8;q=0.7,*;q=0.7')])
         self.assertInBody(zbuf.getvalue()[:3])
 
-        if not HAS_GZIP_COMPRESSION_HEADER_FIXED:
-            # NOTE: CherryPy adopts a fix from the CPython bug 39389
-            # NOTE: introducing a variable compression XFL flag that
-            # NOTE: was hardcoded to "best compression" before. And so
-            # NOTE: we can only test it on CPython versions that also
-            # NOTE: implement this fix.
-            return
         zbuf = io.BytesIO()
         zfile = gzip.GzipFile(mode='wb', fileobj=zbuf, compresslevel=6)
         zfile.write(expectedResult)
@@ -403,9 +385,6 @@ class ToolTests(helper.CPWebCase):
         self.assertBody('I am a tarfile')
 
     def testToolWithConfig(self):
-        if not sys.version_info >= (2, 5):
-            return self.skip('skipped (Python 2.5+ only)')
-
         self.getPage('/tooldecs/blah')
         self.assertHeader('Content-Type', 'application/data')
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,7 @@
 """Test configuration for pytest."""
 
-import sys
-
 
 collect_ignore = [
     # imports win32api, so not viable on some systems
     'cherrypy/process/win32.py',
 ]
-
-
-if sys.version_info < (3, 6):
-    # Modules in docs require Python 3.6
-    collect_ignore.append('docs')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,16 +14,6 @@
 # serve to show the default.
 
 import importlib
-import sys
-
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # fall back for python <= 3.7
-    # This try/except can be removed with py <= 3.7 support
-    import importlib_metadata
-
-assert sys.version_info > (3, 5), 'Python 3 required to build docs'
 
 
 def try_import(mod_name):
@@ -48,7 +38,7 @@ def get_supported_pythons(classifiers):
 
 custom_sphinx_theme = try_import('alabaster')
 
-prj_meta = importlib_metadata.metadata('cherrypy')
+prj_meta = importlib.metadata.metadata('cherrypy')
 prj_author = prj_meta['Author']
 prj_license = prj_meta['License']
 prj_description = prj_meta['Description']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ requires = [
     "setuptools >= 45",
 
     # Plugins
-    "setuptools_scm[toml] >= 7; python_version >= '3.7'",
-    "setuptools_scm[toml] < 7; python_version < '3.7'",
-    "setuptools_scm_git_archive >= 1.1; python_version < '3.7'",
+    "setuptools_scm[toml] >= 7",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -54,7 +54,6 @@ filterwarnings =
   ignore:Use cheroot.test.webtest:DeprecationWarning
   ignore:This method will be removed in future versions.*:DeprecationWarning
   ignore:Unable to verify that the server is bound on:UserWarning
-  ignore:Not importing directory .*.tox/py35/lib/python3.5/site-packages/(zc|repoze).* missing __init__:ImportWarning
   # ref: https://github.com/mhammond/pywin32/issues/1256#issuecomment-527972824 :
   ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning
   ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:PendingDeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # NOTE: tag "py2.py3" which implies (and tricks pip into thinking) that this
 # NOTE: wheel contains Python 2 compatible code. This is not true and conflicts
 # NOTE: with the "Requires-Python" field in the metadata that says that we only
-# NOTE: support Python 3.6+.
+# NOTE: support Python 3+.
 # NOTE: We need to keep it at "0" which will produce wheels tagged with "py3"
 # NOTE: when built under Python 3.
 # Ref: https://github.com/pypa/packaging.python.org/issues/726

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,6 @@ params = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -70,7 +67,6 @@ params = dict(
         'more_itertools',
         'filelock',
         'jaraco.collections',
-        'importlib-metadata; python_version<="3.7"',
     ],
     extras_require={
         'docs': [
@@ -112,7 +108,7 @@ params = dict(
     setup_requires=[
         'setuptools_scm',
     ],
-    python_requires='>=3.6',
+    python_requires='>= 3.9',
 )
 
 


### PR DESCRIPTION
Resolves #2041.

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [x] refactoring
  - [x] other



**What is the related issue number (starting with `#`)**

Resolves #2041

**What is the current behavior?** (You can also link to an open issue here)

EOL versions of Python are still in the CI matrix and trove classifiers.

**What is the new behavior (if this is a feature change)?**

Not anymore.

**Other information**:

https://endoflife.date/python

**Checklist**:

  - [x] I think the code is well written
  - [ ] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [x] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [x] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
