### PR TITLE
fix ssl related documentation of the Server class

### DIFF
--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -109,14 +109,16 @@ class Server(ServerAdapter):
     configuration options."""
 
     ssl_context = None
-    """When using PyOpenSSL, an instance of SSL.Context."""
+    """An instance of SSL context.
+
+    Depending on the `ssl_module`, this can be either
+    `ssl.SSLContext` or `OpenSSL.SSL.Context`."""
 
     ssl_certificate = None
     """The filename of the SSL certificate to use."""
 
     ssl_certificate_chain = None
-    """When using PyOpenSSL, the certificate chain to pass to
-    Context.load_verify_locations."""
+    """The certificate chain to pass to Context.load_verify_locations."""
 
     ssl_private_key = None
     """The filename of the private key to use with SSL."""
@@ -127,8 +129,8 @@ class Server(ServerAdapter):
     ssl_module = 'builtin'
     """The name of a registered SSL adaptation module to use with
     the builtin WSGI server. Builtin options are: 'builtin' (to
-    use the SSL library built into recent versions of Python).
-    You may also register your own classes in the
+    use the SSL library built into Python) or 'pyopenssl' (to use
+    PyOpenSSL). You may also register your own classes in the
     cheroot.server.ssl_adapters dict.
     """
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [X] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other

cherrypy._cpserver.Server documentation incorrectly states that `ssl_certificate_chain` and `ssl_context` are only valid for the `'pyopenssl'` module while I am pretty sure that both of these work with "builtin" one in current version of cheroot as well.

Both of these are passed to the `adapter_class` not matter which one is it:
https://github.com/cherrypy/cherrypy/blob/dca95489342f4bf7bf06fb75d40c58329946f982/cherrypy/_cpnative_server.py#L171 and https://github.com/cherrypy/cherrypy/blob/dca95489342f4bf7bf06fb75d40c58329946f982/cherrypy/_cpwsgi_server.py#L92
and the cheroot `'builtin'` module seems to use them as expected.

I tested passing custom `ssl_context` with restricted TLS versions in my application and it took an effect as one would expect. Compared to the 'pyopenssl' module, it might be creating the default context unnecessarily when it's immediately overwritten, but that shouldn't cause more than a minor performance hit.