### PR TITLE
remove code for unsupported Python versions

### DIFF
--- a/cherrypy/_cpdispatch.py
+++ b/cherrypy/_cpdispatch.py
@@ -261,28 +261,16 @@ class LateParamPageHandler(PageHandler):
         self._kwargs = kwargs
 
 
-if sys.version_info < (3, 0):
-    punctuation_to_underscores = string.maketrans(
-        string.punctuation,
-        '_' * len(string.punctuation),
-    )
+punctuation_to_underscores = str.maketrans(
+    string.punctuation,
+    '_' * len(string.punctuation),
+)
 
-    def validate_translator(t):
-        """Ensure the translator is of the correct length and size."""
-        if not isinstance(t, str) or len(t) != 256:
-            raise ValueError(
-                'The translate argument must be a str of len 256.',
-            )
-else:
-    punctuation_to_underscores = str.maketrans(
-        string.punctuation,
-        '_' * len(string.punctuation),
-    )
 
-    def validate_translator(t):
-        """Ensure the translator is of the correct length and size."""
-        if not isinstance(t, dict):
-            raise ValueError('The translate argument must be a dict.')
+def validate_translator(t):
+    """Ensure the translator is of the correct length and size."""
+    if not isinstance(t, dict):
+        raise ValueError('The translate argument must be a dict.')
 
 
 class Dispatcher(object):

--- a/cherrypy/_cpwsgi_server.py
+++ b/cherrypy/_cpwsgi_server.py
@@ -4,8 +4,6 @@ This adds some CP-specific bits to the framework-agnostic cheroot
 package.
 """
 
-import sys
-
 import cheroot.wsgi
 import cheroot.server
 

--- a/cherrypy/_cpwsgi_server.py
+++ b/cherrypy/_cpwsgi_server.py
@@ -85,10 +85,7 @@ class CPWSGIServer(cheroot.wsgi.Server):
         self.protocol = self.server_adapter.protocol_version
         self.nodelay = self.server_adapter.nodelay
 
-        if sys.version_info >= (3, 0):
-            ssl_module = self.server_adapter.ssl_module or 'builtin'
-        else:
-            ssl_module = self.server_adapter.ssl_module or 'pyopenssl'
+        ssl_module = self.server_adapter.ssl_module or 'builtin'
         if self.server_adapter.ssl_context:
             adapter_class = cheroot.server.get_ssl_adapter_class(ssl_module)
             self.ssl_adapter = adapter_class(

--- a/cherrypy/lib/cpstats.py
+++ b/cherrypy/lib/cpstats.py
@@ -188,7 +188,6 @@ To format statistics reports::
 
 import logging
 import os
-import sys
 import threading
 import time
 

--- a/cherrypy/lib/cpstats.py
+++ b/cherrypy/lib/cpstats.py
@@ -312,9 +312,7 @@ def average_uriset_time(s):
 
 def _get_threading_ident():
     """Discover the current thread identifier."""
-    if sys.version_info >= (3, 3):
-        return threading.get_ident()
-    return threading._get_ident()
+    return threading.get_ident()
 
 
 class StatsTool(cherrypy.Tool):

--- a/cherrypy/test/test_objectmapping.py
+++ b/cherrypy/test/test_objectmapping.py
@@ -1,4 +1,3 @@
-import sys
 import cherrypy
 from cherrypy._cpcompat import ntou
 from cherrypy._cptree import Application

--- a/cherrypy/test/test_objectmapping.py
+++ b/cherrypy/test/test_objectmapping.py
@@ -420,8 +420,6 @@ class ObjectMappingTest(helper.CPWebCase):
         self.assertRaises(TypeError, cherrypy.tree.mount, a, None)
 
     def testKeywords(self):
-        if sys.version_info < (3,):
-            return self.skip('skipped (Python 3 only)')
         exec("""class Root(object):
     @cherrypy.expose
     def hello(self, *, name='world'):

--- a/cherrypy/test/test_params.py
+++ b/cherrypy/test/test_params.py
@@ -45,8 +45,6 @@ class ParamsTest(helper.CPWebCase):
         self.assertStatus(500)
 
     def test_syntax(self):
-        if sys.version_info < (3,):
-            return self.skip('skipped (Python 3 only)')
         code = textwrap.dedent("""
             class Root:
                 @cherrypy.expose

--- a/cherrypy/test/test_params.py
+++ b/cherrypy/test/test_params.py
@@ -1,4 +1,3 @@
-import sys
 import textwrap
 
 import cherrypy

--- a/cherrypy/test/test_request_obj.py
+++ b/cherrypy/test/test_request_obj.py
@@ -2,7 +2,6 @@
 
 from functools import wraps
 import os
-import sys
 import types
 import uuid
 from http.client import IncompleteRead
@@ -708,7 +707,7 @@ class RequestObjectTests(helper.CPWebCase):
             'No, &lt;b&gt;really&lt;/b&gt;, not found!<br />'
             'In addition, the custom error page failed:\n<br />'
             'FileNotFoundError: [Errno 2] '
-            "No such file or directory: 'nonexistent.html'"
+            "No such file or directory: 'nonexistent.html'",
         )
 
         if getattr(cherrypy.server, 'using_apache', False):

--- a/cherrypy/test/test_request_obj.py
+++ b/cherrypy/test/test_request_obj.py
@@ -704,17 +704,12 @@ class RequestObjectTests(helper.CPWebCase):
         # Note that the message is escaped for HTML (ticket #310).
         self.getPage('/error/noexist')
         self.assertStatus(404)
-        if sys.version_info >= (3, 3):
-            exc_name = 'FileNotFoundError'
-        else:
-            exc_name = 'IOError'
-        msg = (
+        self.assertInBody(
             'No, &lt;b&gt;really&lt;/b&gt;, not found!<br />'
             'In addition, the custom error page failed:\n<br />'
-            '%s: [Errno 2] '
+            'FileNotFoundError: [Errno 2] '
             "No such file or directory: 'nonexistent.html'"
-        ) % (exc_name,)
-        self.assertInBody(msg)
+        )
 
         if getattr(cherrypy.server, 'using_apache', False):
             pass

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -264,16 +264,10 @@ class StaticTest(helper.CPWebCase):
         # Check that we get an error if no .file or .dir
         self.getPage('/error/thing.html')
         self.assertErrorPage(500)
-        if sys.version_info >= (3, 3):
-            errmsg = (
-                r'TypeError: staticdir\(\) missing 2 '
-                'required positional arguments'
-            )
-        else:
-            errmsg = (
-                r'TypeError: staticdir\(\) takes at least 2 '
-                r'(positional )?arguments \(0 given\)'
-            )
+        errmsg = (
+            r'TypeError: staticdir\(\) missing 2 '
+            'required positional arguments'
+        )
         self.assertMatchesBody(errmsg.encode('ascii'))
 
     def test_security(self):

--- a/cherrypy/test/test_wsgiapps.py
+++ b/cherrypy/test/test_wsgiapps.py
@@ -42,14 +42,8 @@ class WSGIGraftTests(helper.CPWebCase):
             def __iter__(self):
                 return self
 
-            if sys.version_info >= (3, 0):
-
-                def __next__(self):
-                    return next(self.iter)
-            else:
-
-                def next(self):
-                    return self.iter.next()
+            def __next__(self):
+                return next(self.iter)
 
             def close(self):
                 if hasattr(self.appresults, 'close'):
@@ -63,18 +57,10 @@ class WSGIGraftTests(helper.CPWebCase):
                 results = app(environ, start_response)
 
                 class Reverser(WSGIResponse):
-                    if sys.version_info >= (3, 0):
-
-                        def __next__(this):
-                            line = list(next(this.iter))
-                            line.reverse()
-                            return bytes(line)
-                    else:
-
-                        def next(this):
-                            line = list(this.iter.next())
-                            line.reverse()
-                            return ''.join(line)
+                    def __next__(this):
+                        line = list(next(this.iter))
+                        line.reverse()
+                        return bytes(line)
 
                 return Reverser(results)
 

--- a/cherrypy/test/test_wsgiapps.py
+++ b/cherrypy/test/test_wsgiapps.py
@@ -1,5 +1,3 @@
-import sys
-
 import cherrypy
 from cherrypy._cpcompat import ntob
 from cherrypy.test import helper


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [X] refactoring
  - [ ] other

There are several ocurrences of `sys.version_info` related checks throughout the code base that are now unnecessary considering that the oldest supported Python version is now 3.9 (and these check for either `3` or `3.3`).


**Checklist**:

  - [ ] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
