### PR TITLE
Remove "Freely Distributable" license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ params = dict(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'License :: Freely Distributable',
         'Operating System :: OS Independent',
         'Framework :: CherryPy',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
As mentioned in the comments "License :: Freely Distributable" classifier is fine to drop as pypi.org/classifiers doesn't really specify semantics around this classifier + PEP 639 mandates getting rid of license-related classifiers in favor of SPDX, anyway.

Also https://github.com/cherrypy/cherrypy/commit/cd06246519ab4aada9976ed43ab5aef694b6a59c per the commit it seems like BSD-3-clause classifier was added already and this got missed for the removal.

**What kind of change does this PR introduce?**
  - [X] bug fix



**What is the related issue number (starting with `#`)**
Resolves #1981 

**What is the current behavior?** (You can also link to an open issue here)

**What is the new behavior (if this is a feature change)?**

**Other information**:


**Checklist**:

  - [ ] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [ ] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ ] I used the same coding conventions as the rest of the project
  - [ ] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
