### PR TITLE
Read file in multipart/form-data in bytes

### DIFF
--- a/cherrypy/_cpreqbody.py
+++ b/cherrypy/_cpreqbody.py
@@ -764,12 +764,14 @@ class Part(Entity):
         seen = 0
         boundary_buffer = b''
         while True:
-            line = boundary_buffer + self.fp.read((1 << 16) - len(boundary_buffer))
-            if len(boundary_buffer):
+            line = boundary_buffer + self.fp.read(
+                (1 << 16) - len(boundary_buffer),
+            )
+            if boundary_buffer:
                 boundary_buffer = b''
             if not line:
                 raise EOFError('Illegal end of multipart body.')
-            
+
             # Check if there is a newline within our read
             # and process text up to the newline and
             # store the rest in a buffer for the next pass


### PR DESCRIPTION
**What kind of change does this PR introduce?**
  - [X] bug fix
  - [ ] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [X] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
#2071

**What is the current behavior?** (You can also link to an open issue here)
Read uploaded files in multipart/form-data requests to disk by buffering data into memory using newline (`\n`) characters as separators. There is not a limit on how much data is buffered into memory.

**What is the new behavior (if this is a feature change)?**
Read uploaded files in multipart/form-data requests to disk by buffering data into memory in 64Kb sections. This limits the amount of memory used during uploads. Constantly checks if it reached the end of the form boundary as well.

**Other information**:
Since within the 64Kb read there is a chance the form boundary can be broken up, I check if there is a newline (`\n`) character within the read and buffer it and everything after into a "possible boundary" variable and check it on the next read in case it's a form boundary (and handle it the same as in `read_lines_to_boundary()`.

I added comments to the parts of the code that are new, I can remove on review.

**Checklist**:

  - [X] I think the code is well written
  - [X] I wrote [good commit messages][1]
  - [X] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [X] I used the same coding conventions as the rest of the project
  - [X] The new code doesn't generate linter offenses
  - [X] Documentation reflects the changes
  - [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
