### PR TITLE
Add private key password configuration option

### DIFF
--- a/cherrypy/_cpnative_server.py
+++ b/cherrypy/_cpnative_server.py
@@ -168,20 +168,22 @@ class CPHTTPServer(cheroot.server.HTTPServer):
         self.nodelay = self.server_adapter.nodelay
 
         ssl_module = self.server_adapter.ssl_module or 'pyopenssl'
-        if self.server_adapter.ssl_context:
+
+        setup_tls = (
+            self.server_adapter.ssl_context
+            or self.server_adapter.ssl_certificate
+        )
+
+        if setup_tls:
             adapter_class = cheroot.server.get_ssl_adapter_class(ssl_module)
+            key_password = self.server_adapter.ssl_private_key_password
             self.ssl_adapter = adapter_class(
-                self.server_adapter.ssl_certificate,
-                self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_certificate_chain,
-                self.server_adapter.ssl_ciphers,
+                certificate=self.server_adapter.ssl_certificate,
+                private_key=self.server_adapter.ssl_private_key,
+                certificate_chain=self.server_adapter.ssl_certificate_chain,
+                ciphers=self.server_adapter.ssl_ciphers,
+                private_key_password=key_password,
             )
-            self.ssl_adapter.context = self.server_adapter.ssl_context
-        elif self.server_adapter.ssl_certificate:
-            adapter_class = cheroot.server.get_ssl_adapter_class(ssl_module)
-            self.ssl_adapter = adapter_class(
-                self.server_adapter.ssl_certificate,
-                self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_certificate_chain,
-                self.server_adapter.ssl_ciphers,
-            )
+
+            if self.server_adapter.ssl_context:
+                self.ssl_adapter.context = self.server_adapter.ssl_context

--- a/cherrypy/_cpserver.py
+++ b/cherrypy/_cpserver.py
@@ -121,6 +121,9 @@ class Server(ServerAdapter):
     ssl_private_key = None
     """The filename of the private key to use with SSL."""
 
+    ssl_private_key_password = None
+    """Optional password for private key."""
+
     ssl_ciphers = None
     """The ciphers list of SSL."""
 

--- a/cherrypy/_cpwsgi_server.py
+++ b/cherrypy/_cpwsgi_server.py
@@ -89,23 +89,25 @@ class CPWSGIServer(cheroot.wsgi.Server):
             ssl_module = self.server_adapter.ssl_module or 'builtin'
         else:
             ssl_module = self.server_adapter.ssl_module or 'pyopenssl'
-        if self.server_adapter.ssl_context:
+
+        setup_tls = (
+            self.server_adapter.ssl_context
+            or self.server_adapter.ssl_certificate
+        )
+
+        if setup_tls:
             adapter_class = cheroot.server.get_ssl_adapter_class(ssl_module)
+            key_password = self.server_adapter.ssl_private_key_password
             self.ssl_adapter = adapter_class(
-                self.server_adapter.ssl_certificate,
-                self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_certificate_chain,
-                self.server_adapter.ssl_ciphers,
+                certificate=self.server_adapter.ssl_certificate,
+                private_key=self.server_adapter.ssl_private_key,
+                certificate_chain=self.server_adapter.ssl_certificate_chain,
+                ciphers=self.server_adapter.ssl_ciphers,
+                private_key_password=key_password,
             )
-            self.ssl_adapter.context = self.server_adapter.ssl_context
-        elif self.server_adapter.ssl_certificate:
-            adapter_class = cheroot.server.get_ssl_adapter_class(ssl_module)
-            self.ssl_adapter = adapter_class(
-                self.server_adapter.ssl_certificate,
-                self.server_adapter.ssl_private_key,
-                self.server_adapter.ssl_certificate_chain,
-                self.server_adapter.ssl_ciphers,
-            )
+
+            if self.server_adapter.ssl_context:
+                self.ssl_adapter.context = self.server_adapter.ssl_context
 
         self.stats['Enabled'] = getattr(
             self.server_adapter,

--- a/cherrypy/test/test_config_ssl_adapter.py
+++ b/cherrypy/test/test_config_ssl_adapter.py
@@ -1,0 +1,147 @@
+import pytest
+import trustme
+import ssl
+import cherrypy
+from cherrypy._cpcompat import HTTPSConnection
+from cherrypy import _cpwsgi_server, _cpnative_server
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
+    Encoding,
+    PrivateFormat,
+    load_pem_private_key,
+)
+
+
+@pytest.fixture(scope='session')
+def private_key_password():
+    """Provide hardcoded password for private key."""
+    return 'криївка'
+
+
+@pytest.fixture
+def ssl_cert_and_key(tmp_path, private_key_password):
+    """Create certificate chain and encrypted key as one pem."""
+    ca = trustme.CA()
+    leaf_cert = ca.issue_cert('localhost', '127.0.0.1', '::1')
+    key_as_bytes = leaf_cert.private_key_pem.bytes()
+    private_key_object = load_pem_private_key(
+        key_as_bytes,
+        password=None,
+        backend=default_backend(),
+    )
+
+    encrypted_key_as_bytes = private_key_object.private_bytes(
+        encoding=Encoding.PEM,
+        format=PrivateFormat.PKCS8,
+        encryption_algorithm=BestAvailableEncryption(
+            password=private_key_password.encode('utf-8'),
+        ),
+    )
+
+    key_file = tmp_path / 'encrypted_cert.pem'
+    key_file.write_bytes(
+        encrypted_key_as_bytes
+        + b''.join(cert.bytes() for cert in leaf_cert.cert_chain_pems)
+        + ca.cert_pem.bytes(),
+    )
+
+    return key_file
+
+
+@pytest.fixture
+def trusted_ssl_context(ssl_cert_and_key):
+    """Provide trusted ssl context for the given certificate."""
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ssl_context.verify_mode = ssl.CERT_REQUIRED
+    ssl_context.load_verify_locations(ssl_cert_and_key)
+    return ssl_context
+
+
+@pytest.fixture
+def https_server(
+    request,
+    ssl_cert_and_key,
+    adapter_type,
+    server_type,
+    private_key_password,
+):
+    """Create server configuration and start server."""
+
+    class Root(object):
+        @cherrypy.expose
+        def index(self):
+            return b'Hello World!'
+
+    cherrypy.config.update(
+        {
+            'environment': 'test_suite',
+            'server.socket_host': '0.0.0.0',
+            'server.socket_port': 8000,
+            'server.ssl_module': adapter_type,
+            'server.ssl_certificate': ssl_cert_and_key,
+            'server.ssl_private_key': ssl_cert_and_key,
+            'server.ssl_certificate_chain': ssl_cert_and_key,
+            'server.ssl_private_key_password': private_key_password,
+        },
+    )
+
+    cls = server_type
+    cherrypy.server.httpserver = cls(cherrypy.server)
+    cherrypy.tree.mount(Root(), '/', config={'/': {}})
+    cherrypy.engine.start()
+
+    yield
+
+    cherrypy.engine.exit()
+    cherrypy.server.httpserver = None
+    cherrypy.config.reset()
+    cherrypy.config.update(
+        {
+            'server.ssl_module': None,
+            'server.ssl_certificate': None,
+            'server.ssl_private_key': None,
+            'server.ssl_certificate_chain': None,
+            'server.ssl_private_key_password': None,
+        },
+    )
+
+
+@pytest.fixture
+def https_connection(trusted_ssl_context):
+    """Provide https connection object."""
+    conn = HTTPSConnection(
+        '127.0.0.1',
+        port=cherrypy.server.socket_port,
+        context=trusted_ssl_context,
+    )
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def https_req(https_connection):
+    """Create https request and provide response object."""
+    https_connection.request('GET', '/')
+    resp = https_connection.getresponse()
+    yield resp
+    resp.close()
+
+
+@pytest.mark.parametrize('adapter_type', ('builtin', 'pyopenssl'))
+@pytest.mark.parametrize(
+    'server_type',
+    (_cpwsgi_server.CPWSGIServer, _cpnative_server.CPHTTPServer),
+    ids=('wsgi-server', 'native-server'),
+)
+def test_private_key_password_config_option(
+    https_server,
+    https_req,
+    adapter_type,
+    server_type,
+):
+    """Check that private key password configuration works with servers."""
+    resp = https_req
+    assert resp.read() == b'Hello World!'
+    assert resp.status == 200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 ]
 requires-python = ">= 3.9"
 dependencies = [
-  "cheroot >= 8.2.1",
+  "cheroot >= 11.1.0",
   "portend >= 2.1.1",
   "more_itertools",
   "filelock",
@@ -97,6 +97,7 @@ testing = [
   "requests_toolbelt",
   "pytest-services >= 2",
   "setuptools",
+  "trustme",
 ]
 memcached_session = [
   # Enables memcached session support via `cherrypy[memcached_session]`

--- a/pytest.ini
+++ b/pytest.ini
@@ -56,6 +56,10 @@ filterwarnings =
   # TODO: connection properly.
   ignore:unclosed <socket.socket fd=:ResourceWarning
 
+  # TODO: Builtin ssl-adapter fails to close socket cleanly in server start.
+  # TODO: The culprit is https://github.com/cherrypy/cheroot/issues/302#issuecomment-662592030
+  ignore:unclosed <ssl.SSLSocket fd=:ResourceWarning
+
   # TODO: Remove once `cherrypy._cpreqbody.Part.file` is closed to release
   # TODO: deterministically as well as similar places opening a file descriptor
   # TODO: via `tempfile.TemporaryFile()` but never closing it.

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,7 @@ passenv =
 setenv =
   WEBTEST_INTERACTIVE=false
 extras =
+  ssl
   testing
   routes_dispatcher
   memcached_session


### PR DESCRIPTION
- Adds an option to insert private key password in code or configuration file to avoid typing it manually every time server starts.

- With other commit in cheroot, fixes #1583

**What kind of change does this PR introduce?**
  - [ ] bug fix
  - [ X] feature
  - [ ] docs update
  - [ ] tests/coverage improvement
  - [ ] refactoring
  - [ ] other



**What is the related issue number (starting with `#`)**
#1583


**What is the current behavior?** (You can also link to an open issue here)
If ssl is used and private key has password protection,
the password needs to be entered manually every time the server starts.


**What is the new behavior (if this is a feature change)?**
With this change, the private key password can be inserted via code
or in configuration file.


**Other information**:


**Checklist**:

  - [ X] I think the code is well written
  - [ X] I wrote [good commit messages][1]
  - [ X] I have [squashed related commits together][2] after the changes have been approved
  - [ ] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [ X] I used the same coding conventions as the rest of the project
  - [ X] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [ X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
