### PR TITLE
Fix get_ranges crash when content_length is None

### DIFF
--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -87,6 +87,9 @@ def get_ranges(headervalue, content_length):
     if not headervalue:
         return None
 
+    if content_length is None:
+        return None
+
     result = []
     bytesunit, byteranges = headervalue.split('=', 1)
     for brange in byteranges.split(','):

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -80,3 +80,18 @@ def test_invalid_status(status_code, error_msg):
     """Check that invalid status cause certain errors."""
     with pytest.raises(ValueError, match=error_msg):
         httputil.valid_status(status_code)
+
+
+def test_get_ranges_with_none_content_length():
+    """get_ranges should return None when content_length is None."""
+    assert httputil.get_ranges('bytes=0-10', None) is None
+
+
+def test_get_ranges_with_valid_content_length():
+    """get_ranges should work normally with a valid content_length."""
+    assert httputil.get_ranges('bytes=3-6', 8) == [(3, 7)]
+
+
+def test_get_ranges_with_no_header():
+    """get_ranges should return None when headervalue is empty."""
+    assert httputil.get_ranges(None, 100) is None


### PR DESCRIPTION
When serving resources via `serve_fileobj` (e.g. zipapp resources loaded with `importlib.resources`), `content_length` can be `None`. This causes `get_ranges()` to crash with a `TypeError` when comparing integers against `None`.

This adds an early return of `None` when `content_length is None`, which is consistent with how the function already handles missing Range headers.

Includes regression tests for this case.

**What kind of change does this PR introduce?**
  - [x] bug fix
  - [ ] feature
  - [ ] docs update
  - [x] tests/coverage improvement
  - [ ] refactoring
  - [ ] other

**What is the related issue number (starting with `#`)**

Fixes #2024

**What is the current behavior?** (You can also link to an open issue here)

`get_ranges()` raises `TypeError: '>=' not supported between instances of 'int' and 'NoneType'` when `content_length` is `None`.

**What is the new behavior (if this is a feature change)?**

`get_ranges()` returns `None` when `content_length` is `None`, avoiding the crash.

**Checklist**:

  - [x] I think the code is well written
  - [x] I wrote [good commit messages][1]
  - [x] I have [squashed related commits together][2] after the changes have been approved
  - [x] Unit tests for the changes exist
  - [ ] Integration tests for the changes exist (if applicable)
  - [x] I used the same coding conventions as the rest of the project
  - [x] The new code doesn't generate linter offenses
  - [ ] Documentation reflects the changes
  - [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences

[1]: http://chris.beams.io/posts/git-commit/
[2]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
