### PR TITLE
Fix `staticdir` index trailing-slash redirect (#895)

### DIFF
--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -410,7 +410,16 @@ def staticdir(
         if index:
             handled = _attempt(os.path.join(filename, index), content_types)
             if handled:
-                request.is_index = filename[-1] in (r'\/')
+                # ``filename`` is the directory we just served an index
+                # for; mark the request as an index hit so the
+                # trailing_slash tool (issues/895) can redirect
+                # ``/dir`` to ``/dir/``. The previous expression
+                # ``filename[-1] in (r'\/')`` was structurally False —
+                # ``filename`` here is the resolved directory path and
+                # almost never ends in a separator — so the redirect
+                # never fired and relative links in the index resolved
+                # against the parent URL instead of the directory.
+                request.is_index = True
     return handled
 
 

--- a/cherrypy/test/static/sub/index.html
+++ b/cherrypy/test/static/sub/index.html
@@ -1,0 +1,1 @@
+Hello from sub

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -260,6 +260,30 @@ class StaticTest(helper.CPWebCase):
             '%s/docroot/</a>.' % (self.base(), self.base()),
         )
 
+    def test_subdir_index_redirect(self):
+        """Regression test for #895.
+
+        When ``tools.staticdir.index`` serves an index file from a
+        sub-directory addressed without a trailing slash, the
+        ``trailing_slash`` tool must still issue a 301 to the canonical
+        ``/path/`` form (so relative links in the index resolve against
+        the directory rather than against its parent).
+        """
+        # Sanity: the canonical URL serves the sub-directory index.
+        self.getPage('/docroot/sub/')
+        self.assertStatus('200 OK')
+        self.assertHeader('Content-Type', 'text/html')
+        self.assertBody('Hello from sub\r\n')
+
+        # The buggy line in cherrypy/lib/static.py:413 evaluates
+        # ``filename[-1] in (r'\/')`` on the directory path; that test
+        # is False for ``…/sub`` so ``request.is_index`` was wrongly
+        # set to False and the trailing_slash tool stayed silent.
+        # After the fix, the un-slashed URL must redirect (301).
+        self.getPage('/docroot/sub')
+        self.assertStatus(301)
+        self.assertHeader('Location', '%s/docroot/sub/' % self.base())
+
     def test_config_errors(self):
         # Check that we get an error if no .file or .dir
         self.getPage('/error/thing.html')


### PR DESCRIPTION
## Summary

Fixes #895. The `staticdir` tool was supposed to set `request.is_index = True` when it served an `index.html` from a sub-directory, so that the `trailing_slash` tool could redirect `/dir` → `/dir/` and relative links in the served index would resolve against the directory rather than its parent.

In practice it never did. The offending line on `cherrypy/lib/static.py:413`:

```python
request.is_index = filename[-1] in (r'\/')
```

…is structurally `False`: at that point `filename` is the **directory path** (the result of `os.path.join(section, branch)`), and that almost never ends in a `/` or `\`. So `is_index` was set to `False` on every directory hit, and `trailing_slash` took the `elif request.is_index is False` branch (`cherrypy/lib/cptools.py:560-572`) — i.e. stayed silent.

The fix is a one-line change: unconditionally set `request.is_index = True` inside the `if handled:` block, since by then we know we're serving an index for a directory. A code comment explains the **why** so a reviewer reading the diff cold doesn't have to re-derive the reasoning.

The bug was introduced in commit `3677bda13` (2007) and reported in 2009 (#895), so it has shipped quietly for ~17 years. The reason it never surfaced as a CI failure is that the existing tests only exercise the top-level `/docroot/` URL, which the dispatcher already routes via a different path.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# Setup
git clone https://github.com/cherrypy/cherrypy.git /tmp/cp-repro && cd /tmp/cp-repro
uv venv && source .venv/bin/activate && uv pip install -e ".[testing]"

# BEFORE — origin/main: the new regression test fails (un-slashed URL returns 200 instead of 301)
git fetch origin && git checkout origin/main
# Apply only the test file from this PR so the test exists on main:
git fetch https://github.com/jbbqqf/cherrypy.git fix/895-staticdir-is-index
git checkout FETCH_HEAD -- cherrypy/test/test_static.py cherrypy/test/static/sub/index.html
pytest cherrypy/test/test_static.py::StaticTest::test_subdir_index_redirect -v --no-cov
# Expected: FAILED — `Status 200 OK does not match 301`

# AFTER — the fix branch: the regression test passes
git checkout FETCH_HEAD
pytest cherrypy/test/test_static.py::StaticTest::test_subdir_index_redirect -v --no-cov
# Expected: PASSED
```

## What I ran locally

| Command | Result |
|---|---|
| `pytest cherrypy/test/test_static.py -v --no-cov` (with fix) | 15 passed, 1 skipped (Windows-only), 1 xpassed (#1475) |
| `pytest cherrypy/test/test_static.py::StaticTest::test_subdir_index_redirect -v --no-cov` (without fix) | 1 failed — `Status 200 OK does not match 301` |
| `pytest cherrypy/test/test_static.py::StaticTest::test_subdir_index_redirect -v --no-cov` (with fix) | 1 passed |
| `pytest cherrypy/test/test_misc_tools.py cherrypy/test/test_tools.py --no-cov` (sanity, `trailing_slash` lives in `cptools`) | 22 passed |

Python 3.12.13, fresh `uv venv`, `cherrypy==18.10.1.dev214+g1f75bc9ee.d20260522`.

## Edge cases

| Scenario | Before | After |
|---|---|---|
| `GET /docroot/sub/` (canonical, trailing slash) — serves `sub/index.html` | 200 OK with `Hello from sub` | 200 OK with `Hello from sub` (unchanged) |
| `GET /docroot/sub` (no trailing slash, directory served by `staticdir.index`) | 200 OK — **trailing-slash redirect silently dropped, relative links in index break** | 301 redirect to `/docroot/sub/` (correct) |
| `GET /docroot/foo.html` (a regular file under the static dir, not a directory) | `is_index` left at `False` (handler falls through `_attempt`) | Same — only the `if index and handled:` branch is touched, so non-index hits are untouched |
| Top-level `GET /docroot/` (the case the existing `test_serve_dir` covers) | Already worked via the dispatcher | Unchanged |

## Related

- Original report: #895 (2009)
- Same surface, different bug: the `trailing_slash` tool's `is_index` contract is documented in `cherrypy/lib/cptools.py:551-573`.
- Introducing commit: `3677bda13` (Robert Brewer, 2007-06-16).

---

*Disclosure: I drafted this PR — patch, test, and body — with help from Claude Code. The evidence cited above (file paths, line numbers, git blame, before/after pytest output) was verified manually before submission.*
