### PR TITLE
Cap number of ranges honored in a Range header to prevent DoS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 v(next)
 -------
 
+* Fixed a denial-of-service issue where a ``Range`` header specifying
+  an excessive number of byte-ranges could force disproportionate
+  server-side work when serving a file (similar in spirit to the
+  well-known Apache "Range header" DoS, e.g. CVE-2011-3192). Requests
+  specifying more than :data:`~cherrypy.lib.httputil.MAX_RANGES`
+  (100) ranges now have their ``Range`` header treated as invalid,
+  falling back to serving the full response.
+
 * Dropped support for Python 3.6, 3.7 and 3.8
   -- by :user:`webknjaz`.
 

--- a/cherrypy/lib/httputil.py
+++ b/cherrypy/lib/httputil.py
@@ -26,6 +26,18 @@ from .._private_api.compat.headers import parse_header
 
 response_codes = BaseHTTPRequestHandler.responses.copy()
 
+# A Range header requesting more than this many byte-ranges is treated
+# as invalid (the Range header is ignored and the full entity is
+# served instead). Without a cap, a request specifying a very large
+# number of ranges -- especially many small, overlapping, or
+# duplicate ranges over a large resource -- can force the server to
+# seek/read/emit the resource once per range, giving a small request
+# disproportionate server-side CPU, memory, and I/O cost. This is the
+# same class of issue as the well-known "Range header" DoS (e.g. CVE-
+# 2011-3192) that other servers such as Apache httpd mitigated by
+# similarly bounding the number of ranges they will honor.
+MAX_RANGES = 100
+
 # From https://github.com/cherrypy/cherrypy/issues/361
 response_codes[500] = (
     'Internal Server Error',
@@ -89,7 +101,15 @@ def get_ranges(headervalue, content_length):
 
     result = []
     bytesunit, byteranges = headervalue.split('=', 1)
-    for brange in byteranges.split(','):
+    range_specs = byteranges.split(',')
+    if len(range_specs) > MAX_RANGES:
+        # Too many ranges requested. Treating the header as invalid
+        # (rather than honoring it) matches the RFC 2616 sec 14.16
+        # guidance already followed elsewhere in this function for
+        # other malformed Range headers: fall back to serving the
+        # full, unranged response. See MAX_RANGES above for why.
+        return None
+    for brange in range_specs:
         start, stop = [x.strip() for x in brange.split('-', 1)]
         if start:
             if not stop:

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -115,9 +115,7 @@ def test_get_ranges_excessive_range_count_rejected():
     assert len(result) == httputil.MAX_RANGES
 
     # One over the limit: rejected.
-    over_limit = 'bytes=' + ','.join(
-        ['1-2929'] * (httputil.MAX_RANGES + 1)
-    )
+    over_limit = 'bytes=' + ','.join(['1-2929'] * (httputil.MAX_RANGES + 1))
     assert httputil.get_ranges(over_limit, content_length) is None
 
     # A large attack-sized header is also rejected.
@@ -125,7 +123,11 @@ def test_get_ranges_excessive_range_count_rejected():
     assert httputil.get_ranges(many_ranges, content_length) is None
 
     # Legitimate, small multi-range requests remain unaffected.
-    assert httputil.get_ranges('bytes=0-99,200-299,400-499', content_length) == [
-        (0, 100), (200, 300), (400, 500),
+    assert httputil.get_ranges(
+        'bytes=0-99,200-299,400-499',
+        content_length,
+    ) == [
+        (0, 100),
+        (200, 300),
+        (400, 500),
     ]
-

--- a/cherrypy/test/test_httputil.py
+++ b/cherrypy/test/test_httputil.py
@@ -80,3 +80,52 @@ def test_invalid_status(status_code, error_msg):
     """Check that invalid status cause certain errors."""
     with pytest.raises(ValueError, match=error_msg):
         httputil.valid_status(status_code)
+
+
+def test_get_ranges_normal_cases():
+    """Ordinary Range headers should be parsed as before."""
+    assert httputil.get_ranges('bytes=3-6', 8) == [(3, 7)]
+    assert httputil.get_ranges('bytes=2-4,-1', 8) == [(2, 5), (7, 8)]
+    assert httputil.get_ranges('bytes=-100', 8) == [(0, 8)]
+    assert httputil.get_ranges('', 8) is None
+    assert httputil.get_ranges(None, 8) is None
+
+
+def test_get_ranges_excessive_range_count_rejected():
+    """
+    Regression test for
+    https://github.com/cherrypy/cherrypy/issues/1290
+
+    A Range header specifying an excessive number of byte-ranges (e.g.
+    many duplicate/overlapping small ranges over a large resource) can
+    force the server to seek/read/emit the resource once per range,
+    giving a small request disproportionate server-side cost -- the
+    same class of issue as the well-known "Range header" DoS (e.g. CVE
+    -2011-3192). get_ranges() should treat such a header as invalid
+    (returning None, which callers already treat as "ignore the Range
+    header and serve the full response") rather than returning an
+    unbounded list of ranges.
+    """
+    content_length = 100000
+
+    # At the limit: still honored normally.
+    at_limit = 'bytes=' + ','.join(['1-2929'] * httputil.MAX_RANGES)
+    result = httputil.get_ranges(at_limit, content_length)
+    assert result is not None
+    assert len(result) == httputil.MAX_RANGES
+
+    # One over the limit: rejected.
+    over_limit = 'bytes=' + ','.join(
+        ['1-2929'] * (httputil.MAX_RANGES + 1)
+    )
+    assert httputil.get_ranges(over_limit, content_length) is None
+
+    # A large attack-sized header is also rejected.
+    many_ranges = 'bytes=' + ','.join(['1-2929'] * 1300)
+    assert httputil.get_ranges(many_ranges, content_length) is None
+
+    # Legitimate, small multi-range requests remain unaffected.
+    assert httputil.get_ranges('bytes=0-99,200-299,400-499', content_length) == [
+        (0, 100), (200, 300), (400, 500),
+    ]
+


### PR DESCRIPTION
Fixes #1290.

`get_ranges()` parsed every comma-separated byte-range in a `Range` header with no limit on how many there could be. When serving a file with more than one range requested, `serve_fileobj()` seeks, reads, and emits the file once per range in the list. A request specifying a very large number of ranges -- especially many small, duplicate, or overlapping ranges over a large resource, as in the classic attack payload from this issue (`bytes=1-2929,1-2929,...` repeated hundreds of times) -- can therefore force the server to do a disproportionate amount of seeking, reading, and output generation for a small request. This is the same class of issue as the well-known Apache httpd Range header DoS (CVE-2011-3192), which Apache mitigated by similarly bounding the ranges it would honor.

**Fix**: add a `MAX_RANGES` constant (100) and, when a `Range` header specifies more ranges than that, treat the header as invalid -- returning `None`, which every existing caller already handles by falling back to serving the full, unranged response. This reuses the exact fallback path RFC 2616 sec 14.16 already prescribes (and this function already implements) for other malformed Range headers, rather than introducing new response-handling logic.

**Testing**: added regression tests -- one confirming ordinary Range headers parse exactly as before, and one that reproduces the issue's attack pattern (matching its `bytes=1-2929,1-2929,...` payload shape) plus boundary cases (exactly at the limit still honored, one over rejected, a large attack-sized header rejected), and confirms small legitimate multi-range requests are unaffected. I confirmed the new DoS test fails against the original unbounded implementation and passes with the fix.

Ran the existing `test_httputil.py` suite (27 tests, all pass) and the existing live-server Range-header integration test in `test_core.py` (functionally passes -- status codes 200/206/416 all correct in the request log; the one pytest failure is an unrelated pre-existing `ResourceWarning` about file handle cleanup, present identically on a clean checkout of `main`).

Chose 100 as a reasonable default limit, open to adjusting if maintainers prefer a different number or would rather this be configurable.
