### PR TITLE
Honor If-Range when serving static files with Range requests

### DIFF
--- a/cherrypy/lib/static.py
+++ b/cherrypy/lib/static.py
@@ -205,7 +205,23 @@ def _serve_fileobj(fileobj, content_type, content_length, debug=False):
     request = cherrypy.serving.request
     if request.protocol >= (1, 1):
         response.headers['Accept-Ranges'] = 'bytes'
-        r = httputil.get_ranges(request.headers.get('Range'), content_length)
+        range_header = request.headers.get('Range')
+        if range_header:
+            # If-Range makes a Range request conditional: if the
+            # validator doesn't match the resource's current state
+            # (e.g. the client's cached copy is stale), the full
+            # resource must be sent with status 200, ignoring Range
+            # entirely, rather than honoring it and sending back
+            # (possibly now-incorrect) partial content. Compare via
+            # simple string equality against the Last-Modified value,
+            # matching the same approach validate_since() already
+            # uses for If-Modified-Since/If-Unmodified-Since, which
+            # works correctly because HTTPDate formatting is
+            # deterministic. See GH #1699.
+            if_range = request.headers.get('If-Range')
+            if if_range and if_range != response.headers.get('Last-Modified'):
+                range_header = None
+        r = httputil.get_ranges(range_header, content_length)
         if r == []:
             response.headers['Content-Range'] = 'bytes */%s' % content_length
             message = (

--- a/cherrypy/test/test_static.py
+++ b/cherrypy/test/test_static.py
@@ -297,6 +297,45 @@ class StaticTest(helper.CPWebCase):
         self.assertNoHeader('Content-Disposition')
         self.assertBody('')
 
+    def test_if_range(self):
+        # Regression test for GH #1699: a Range request whose If-Range
+        # validator doesn't match the resource's current Last-Modified
+        # value must return the full resource with status 200, per
+        # RFC 7233 section 3.2, rather than honoring the Range request.
+        self.getPage('/static/dirback.jpg')
+        self.assertStatus('200 OK')
+        full_body = self.body
+        lastmod = ''
+        for k, v in self.headers:
+            if k == 'Last-Modified':
+                lastmod = v
+        assert lastmod
+
+        # Stale If-Range (doesn't match current Last-Modified): the
+        # full resource must be returned with status 200, Range ignored.
+        stale_if_range = ('If-Range', 'Tue, 21 Nov 2017 14:43:11 GMT')
+        self.getPage(
+            '/static/dirback.jpg',
+            headers=[('Range', 'bytes=0-9'), stale_if_range],
+        )
+        self.assertStatus('200 OK')
+        self.assertBody(full_body)
+
+        # If-Range matching the current Last-Modified: Range must
+        # still be correctly honored, status 206.
+        matching_if_range = ('If-Range', lastmod)
+        self.getPage(
+            '/static/dirback.jpg',
+            headers=[('Range', 'bytes=0-9'), matching_if_range],
+        )
+        self.assertStatus('206 Partial Content')
+        self.assertBody(full_body[:10])
+
+        # No If-Range at all: normal Range behavior is unaffected.
+        self.getPage('/static/dirback.jpg', headers=[('Range', 'bytes=0-9')])
+        self.assertStatus('206 Partial Content')
+        self.assertBody(full_body[:10])
+
     def test_755_vhost(self):
         self.getPage('/test/', [('Host', 'virt.net')])
         self.assertStatus(200)


### PR DESCRIPTION
Fixes #1699.

`_serve_fileobj()` parsed and applied the `Range` header unconditionally, with no handling of `If-Range` at all. Per RFC 7233 section 3.2, `If-Range` makes a `Range` request conditional: if the validator doesn't match the resource's current state (e.g. the client's cached copy is stale), the server must send the full resource with status 200, ignoring the `Range` request entirely, rather than honoring it and sending back partial content that may no longer correspond to what the client actually has cached. This matches the exact scenario in the issue: browsers commonly send both `Range` and a stale `If-Range` after a hard-refresh invalidates part of the cache, and CherryPy was incorrectly always returning 206 regardless.

**Fix**: compare the incoming `If-Range` header against the resource's current `Last-Modified` value (already set in `response.headers` by `serve_file()` before `_serve_fileobj()` runs) via simple string equality, matching the same approach `validate_since()` already uses for `If-Modified-Since`/`If-Unmodified-Since` elsewhere in the codebase -- this works correctly because HTTPDate formatting is deterministic, so no actual date parsing/comparison is needed. If `If-Range` is present and doesn't match, the `Range` header is treated as absent for the rest of this function, falling through to the existing "serve the full resource" code path unchanged.

**Testing**: verified against a real, live CherryPy server (not mocks): confirmed a `Range` request with a stale `If-Range` (a past date not matching the file's actual `Last-Modified`) previously always returned 206 with partial content, and now correctly returns the full file with status 200. Also verified: an `If-Range` that exactly matches the current `Last-Modified` still correctly honors the `Range` request (206, partial content), and a plain `Range` request with no `If-Range` at all is completely unaffected (still 206).

Added a regression test using the existing `StaticTest` test class and `getPage()`/`assertStatus()` conventions, covering all three cases above. I confirmed the test fails with the original code (206 where 200 was expected) and passes with the fix. Ran the full existing `test_static.py` suite; the only failures observed (on both the fixed and a clean, unmodified checkout, confirmed by running each 3 times) are pre-existing, GC-timing-dependent `ResourceWarning` flakiness in `test_file_stream`'s large-file fixture (already tracked as GH #1475), unrelated to this change and appearing on a different, unrelated test each run.
