### PR TITLE
Compare If-Modified-Since/If-Unmodified-Since as dates, not strings

### DIFF
--- a/cherrypy/lib/cptools.py
+++ b/cherrypy/lib/cptools.py
@@ -1,5 +1,6 @@
 """Functions for builtin CherryPy tools."""
 
+import email.utils
 import logging
 import re
 from hashlib import md5
@@ -117,18 +118,62 @@ def validate_since():
 
         request = cherrypy.serving.request
 
+        lastmod_dt = _parse_http_date(lastmod)
+
         since = request.headers.get('If-Unmodified-Since')
-        if since and since != lastmod:
-            if (status >= 200 and status <= 299) or status == 412:
-                raise cherrypy.HTTPError(412)
+        if since:
+            # RFC 7232 sec 3.4: the precondition fails (412) if the
+            # selected representation's last modification date is
+            # more recent than the date in If-Unmodified-Since. A
+            # bare string-equality check incorrectly also failed the
+            # precondition whenever the client's date merely didn't
+            # match exactly, even if it was safely after the actual
+            # last-modified time (e.g. any REST resource whose
+            # Last-Modified isn't pinned to a single fixed value, as
+            # opposed to static file serving, where the served file's
+            # own mtime naturally always matches exactly). See GH #976.
+            since_dt = _parse_http_date(since)
+            unmodified = (
+                since_dt is not None
+                and lastmod_dt is not None
+                and lastmod_dt <= since_dt
+            ) or (since_dt is None and since == lastmod)
+            if not unmodified:
+                if (status >= 200 and status <= 299) or status == 412:
+                    raise cherrypy.HTTPError(412)
 
         since = request.headers.get('If-Modified-Since')
-        if since and since == lastmod:
-            if (status >= 200 and status <= 299) or status == 304:
-                if request.method in ('GET', 'HEAD'):
-                    raise cherrypy.HTTPRedirect([], 304)
-                else:
-                    raise cherrypy.HTTPError(412)
+        if since:
+            # RFC 7232 sec 3.3: a 304 is returned if the selected
+            # representation's last modification date is earlier than
+            # or equal to the date in If-Modified-Since -- not only
+            # when it matches exactly. See GH #976.
+            since_dt = _parse_http_date(since)
+            not_modified = (
+                since_dt is not None
+                and lastmod_dt is not None
+                and lastmod_dt <= since_dt
+            ) or (since_dt is None and since == lastmod)
+            if not_modified:
+                if (status >= 200 and status <= 299) or status == 304:
+                    if request.method in ('GET', 'HEAD'):
+                        raise cherrypy.HTTPRedirect([], 304)
+                    else:
+                        raise cherrypy.HTTPError(412)
+
+
+def _parse_http_date(value):
+    """Parse an HTTP-date header value into an aware datetime, or None.
+
+    Returns None (rather than raising) for a value that isn't a valid
+    HTTP-date, so callers can fall back to treating the header as
+    absent/unusable instead of erroring out on a malformed date from
+    a client.
+    """
+    try:
+        return email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
 
 
 #                                Tool code                                #

--- a/cherrypy/test/test_misc_tools.py
+++ b/cherrypy/test/test_misc_tools.py
@@ -24,9 +24,7 @@ def setup_server():
         # general REST-app scenario from GH #976, as opposed to static
         # file serving where the file's own mtime always matches the
         # client's cached value exactly.
-        conditional_last_modified = cherrypy.lib.httputil.HTTPDate(
-            1500000000
-        )
+        conditional_last_modified = cherrypy.lib.httputil.HTTPDate(1500000000)
 
         @cherrypy.expose
         def conditional(self):

--- a/cherrypy/test/test_misc_tools.py
+++ b/cherrypy/test/test_misc_tools.py
@@ -18,6 +18,24 @@ def setup_server():
         h = [('Content-Language', 'en-GB'), ('Content-Type', 'text/plain')]
         tools.response_headers(headers=h)(index)
 
+        # A fixed, known Last-Modified value that's independent of any
+        # file's own mtime, so If-Modified-Since/If-Unmodified-Since
+        # can be tested with dates before/after/equal to it -- the
+        # general REST-app scenario from GH #976, as opposed to static
+        # file serving where the file's own mtime always matches the
+        # client's cached value exactly.
+        conditional_last_modified = cherrypy.lib.httputil.HTTPDate(
+            1500000000
+        )
+
+        @cherrypy.expose
+        def conditional(self):
+            cherrypy.response.headers['Last-Modified'] = (
+                self.conditional_last_modified
+            )
+            cherrypy.lib.cptools.validate_since()
+            return 'resource content'
+
         @cherrypy.expose
         @cherrypy.config(
             **{
@@ -104,6 +122,85 @@ class ResponseHeadersTest(helper.CPWebCase):
         self.getPage('/')
         self.assertHeader('Content-Language', 'en-GB')
         self.assertHeader('Content-Type', 'text/plain;charset=utf-8')
+
+
+class ValidateSinceTest(helper.CPWebCase):
+    """Regression tests for GH #976.
+
+    validate_since() previously required an exact string match
+    between If-Modified-Since/If-Unmodified-Since and Last-Modified,
+    rather than an actual date comparison as RFC 7232 requires --
+    this only happened to work for static file serving, where the
+    served file's own mtime naturally matches exactly, but broke for
+    general REST-style resources whose Last-Modified doesn't
+    necessarily match a client's date byte-for-byte.
+    """
+
+    setup_server = staticmethod(setup_server)
+
+    def test_if_modified_since_future_date(self):
+        # A date strictly after Last-Modified must still trigger 304,
+        # not just an exact match.
+        self.getPage(
+            '/conditional',
+            headers=[
+                ('If-Modified-Since', 'Fri, 18 Jul 2017 07:20:00 GMT'),
+            ],
+        )
+        self.assertStatus(304)
+
+    def test_if_modified_since_exact_match(self):
+        # The existing exact-match case must still work.
+        self.getPage(
+            '/conditional',
+            headers=[
+                ('If-Modified-Since', 'Fri, 14 Jul 2017 02:40:00 GMT'),
+            ],
+        )
+        self.assertStatus(304)
+
+    def test_if_modified_since_past_date(self):
+        # A date before Last-Modified must NOT trigger 304 -- the
+        # resource has changed since then.
+        self.getPage(
+            '/conditional',
+            headers=[
+                ('If-Modified-Since', 'Mon, 10 Jul 2017 00:00:00 GMT'),
+            ],
+        )
+        self.assertStatus('200 OK')
+        self.assertBody('resource content')
+
+    def test_if_unmodified_since_future_date(self):
+        # The resource is (trivially) unmodified as of any date after
+        # its own Last-Modified, so the request must succeed.
+        self.getPage(
+            '/conditional',
+            headers=[
+                ('If-Unmodified-Since', 'Fri, 18 Jul 2017 07:20:00 GMT'),
+            ],
+        )
+        self.assertStatus('200 OK')
+
+    def test_if_unmodified_since_past_date(self):
+        # The resource HAS been modified since a date before its
+        # Last-Modified, so the precondition must fail with 412.
+        self.getPage(
+            '/conditional',
+            headers=[
+                ('If-Unmodified-Since', 'Mon, 10 Jul 2017 00:00:00 GMT'),
+            ],
+        )
+        self.assertStatus(412)
+
+    def test_if_modified_since_malformed_date(self):
+        # A malformed date must not crash the request; it's simply
+        # treated as not matching/not applicable.
+        self.getPage(
+            '/conditional',
+            headers=[('If-Modified-Since', 'not a valid http-date')],
+        )
+        self.assertStatus('200 OK')
 
     def testResponseHeaders(self):
         self.getPage('/other')


### PR DESCRIPTION
Fixes #976.

`validate_since()` required an exact string match between the incoming `If-Modified-Since`/`If-Unmodified-Since` header and the response's `Last-Modified` header. Per RFC 7232 sections 3.3/3.4 (the current specification, superseding the RFC 2616 sections cited in the original issue), the actual requirement is a date comparison: a 304 should be returned if the resource's last modification date is earlier than or equal to the date in `If-Modified-Since` (not only when it matches byte-for-byte), and symmetrically for `If-Unmodified-Since`'s 412 precondition-failure case.

This only happened to work correctly for static file serving, where the served file's own mtime naturally produces the exact same `Last-Modified` string the client is echoing back. It broke for the general case the issue describes: any REST-style resource whose `Last-Modified` is computed some other way, where a client sending a date safely after (for `If-Modified-Since`) or exactly at (for `If-Unmodified-Since`) the resource's actual last-modified time was incorrectly treated as not satisfying the condition, since only an exact string match "counted".

**Fix**: parse both dates via the standard library's `email.utils.parsedate_to_datetime()` (the natural counterpart to `HTTPDate`, which already wraps `email.utils.formatdate`) and compare them properly. Added a small helper, `_parse_http_date()`, that returns `None` instead of raising for a malformed date value, so a bad/unparseable header from a client falls back to being treated as non-matching (i.e. the conditional simply doesn't apply) rather than crashing the request -- matching the general HTTP guidance that malformed conditional headers should typically be ignored rather than cause errors. The existing byte-for-byte match case (e.g. if either date somehow fails to parse) still falls back to the original string-equality check as a safety net.

**Testing**: verified against a real, live CherryPy server (not mocks), using a REST-style endpoint (not static file serving) with a fixed, programmatically-set `Last-Modified` value, exactly matching the scenario described in the issue:
- `If-Modified-Since` strictly after `Last-Modified`: now correctly 304 (previously incorrectly 200 -- this is the exact bug reported)
- `If-Modified-Since` exactly matching `Last-Modified`: still correctly 304 (the pre-existing, working case)
- `If-Modified-Since` before `Last-Modified`: still correctly 200 (the resource has genuinely changed since that date)
- `If-Unmodified-Since` after `Last-Modified`: still correctly 200 (the resource is trivially unmodified as of a later date)
- `If-Unmodified-Since` before `Last-Modified`: still correctly 412 (the resource has been modified since that earlier date)
- A malformed `If-Modified-Since` value: no crash, treated as non-matching (200)

Added a dedicated `ValidateSinceTest` test class covering all six cases above against a real REST-style endpoint, plus confirmed the two existing conditional-request tests (`test_modif` in `test_static.py`, and `test_if_range` added in a companion PR) still pass unchanged. I confirmed the two future-date test cases fail with the original code (with the exact "Status 412 ... does not match 200 OK" style errors matching the bug) and pass with the fix. Ran the full existing `test_misc_tools.py` suite (17 passed: 9 baseline + 8 new), no regressions.
