### PR TITLE
Fix multi-encoding fallback losing a file-like response body

### DIFF
--- a/cherrypy/lib/encoding.py
+++ b/cherrypy/lib/encoding.py
@@ -125,6 +125,21 @@ class ResponseEncoder:
         if encoding in self.attempted_charsets:
             return False
         self.attempted_charsets.add(encoding)
+        # self.body may still be a one-shot generator/file-object
+        # wrapper (see prepare_iter()) rather than a list. Iterating
+        # it here to attempt an encoding would consume it, and if
+        # this encoding attempt fails partway through (a later
+        # encode() call raises), self.body was never reassigned --
+        # leaving it pointing at the now partially-or-fully-exhausted
+        # original iterator, so any subsequent encoding attempt (e.g.
+        # for the next charset in the client's Accept-Charset list)
+        # would incorrectly see an empty body. Materialize it into a
+        # list once, up front: this is always safe to do here, since
+        # encode_string() is only used for the non-streaming case,
+        # where the entire body needs to be fully buffered in memory
+        # regardless. See GH #1215.
+        if not isinstance(self.body, list):
+            self.body = list(self.body)
         body = []
         for chunk in self.body:
             if isinstance(chunk, str):

--- a/cherrypy/test/test_encoding.py
+++ b/cherrypy/test/test_encoding.py
@@ -18,6 +18,11 @@ sing = ntou('毛泽东: Sing, Little Birdie?', encoding='utf-8')
 sing8 = sing.encode('utf-8')
 sing16 = sing.encode('utf-16')
 
+# U+2026 HORIZONTAL ELLIPSIS: encodable as UTF-8, but has no
+# representation in ISO-8859-1 -- the exact character from GH #1215's
+# reproduction.
+ellipsis_char = 'Hello\u2026World'
+
 
 class EncodingTests(helper.CPWebCase):
     @staticmethod
@@ -39,6 +44,17 @@ class EncodingTests(helper.CPWebCase):
             @cherrypy.config(**{'tools.encode.encoding': 'utf-8'})
             def utf8(self):
                 return sing8
+
+            @cherrypy.expose
+            def file_like_body(self):
+                # A genuine file-like (non-list) body, as opposed to
+                # the plain-string bodies used by mao_zedong/utf8
+                # above: prepare_iter() wraps this via file_generator()
+                # rather than a plain list, exercising the exact
+                # generator-exhaustion scenario from GH #1215 (the
+                # issue's own reproduction used `return open(...)`,
+                # a text-mode file yielding str chunks).
+                return io.StringIO(ellipsis_char)
 
             @cherrypy.expose
             def cookies_and_headers(self):
@@ -459,6 +475,27 @@ class EncodingTests(helper.CPWebCase):
             [('Accept-Charset', 'ISO-8859-1,utf-8;q=0.7,*;q=0.7)')],
         )
         self.assertStatus('400 Bad Request')
+
+    def test_multiple_encodings_file_like_body(self):
+        """
+        Regression test for
+        https://github.com/cherrypy/cherrypy/issues/1215
+
+        When multiple encodings must be attempted (e.g. the client's
+        Accept-Charset lists ISO-8859-1 before UTF-8, and the content
+        can't be represented in ISO-8859-1), a *file-like* response
+        body (as opposed to a plain string) must not end up empty by
+        the time a later, successful encoding is attempted. The
+        original bug's own reproduction returned an open() file
+        object directly; this uses io.StringIO for the same effect
+        without needing an actual file on disk.
+        """
+        self.getPage(
+            '/file_like_body',
+            [('Accept-Charset', 'iso-8859-1;q=1, utf-8;q=0.5')],
+        )
+        self.assertHeader('Content-Type', 'text/html;charset=utf-8')
+        self.assertBody(ellipsis_char.encode('utf-8'))
 
     def testGzip(self):
         zbuf = io.BytesIO()


### PR DESCRIPTION
Fixes #1215.

`find_acceptable_charset()` may attempt several encodings in sequence (per the client's `Accept-Charset` preferences) via `encode_string()`, stopping at the first one that succeeds. `encode_string()` iterated `self.body` directly to build the encoded output, but `self.body` may still be a one-shot generator/file-object wrapper (see `prepare_iter()`, used for any response whose handler returns a file-like object, e.g. `return open(path)`) rather than a plain list.

If the first encoding attempt failed partway through (e.g. the content contains a character with no representation in that charset), `self.body` was never reassigned -- but the generator had already been consumed while attempting that failed encoding. Any subsequent attempt for the next charset in the client's list then iterated an already-exhausted generator, silently producing an empty body instead of the actual content -- exactly the "blank page" symptom described in the issue, which the original reporter correctly traced to a real chromium/chrome browser sending both ISO-8859-1 and UTF-8 in its `Accept-Charset` header for a page containing a non-ISO-8859-1 character. (The reporter's own Python 2 vs 3 theory was a plausible-sounding red herring; the actual root cause -- destructive iteration of a one-shot body across multiple encoding attempts -- is Python-version-independent.)

**Fix**: since `encode_string()` is only ever used for the non-streaming case (`response.stream` is `False`), where the entire body must be fully buffered in memory regardless, materializing `self.body` into a list before the first encoding attempt has no real downside: subsequent calls see `self.body` is already a list and skip re-materializing, safely re-iterating the same, stable list of original (unencoded) chunks for each successive attempt.

**Testing**: verified directly: constructed a minimal file-like body (matching `prepare_iter()`'s `file_generator()` wrapping) containing a character with no ISO-8859-1 representation, and confirmed a first (failing) ISO-8859-1 attempt followed by a second (successful) UTF-8 attempt previously produced an empty result; with the fix, the second attempt correctly sees and encodes the full original content.

Added a regression test against a real, live CherryPy server using a new endpoint that returns an `io.StringIO` body (a genuine file-like, non-list body, unlike this test file's existing plain-string-based endpoints), sending an `Accept-Charset` header requesting ISO-8859-1 before UTF-8, matching the exact browser behavior described in the issue. I confirmed the test fails with the original code (actual body is empty) and passes with the fix. Ran the full existing `test_encoding.py` suite (14 passed: 13 baseline + 1 new), no regressions.
